### PR TITLE
Extract predicate keys into Class method

### DIFF
--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -109,7 +109,7 @@ module Ransack
         output
       end
 
-      def predicate_keys(options)
+      def self.predicate_keys(options={})
         options[:compounds] = true if options[:compounds].nil?
         keys = options[:compounds] ? Predicate.names : Predicate.names.reject {|k| k.match(/_(any|all)$/)}
         if only = options[:only]
@@ -124,7 +124,7 @@ module Ransack
       end
 
       def predicate_select(options = {}, html_options = {})
-        keys = predicate_keys(options)
+        keys = FormBuilder.predicate_keys(options)
 
         @template.collection_select(
           @object_name, :p, keys.map {|k| [k, Translate.predicate(k)]}, :first, :last,


### PR DESCRIPTION
I'd like to be able to access the predicates used by Ransack outside of having an instantiated form builder object.  My intended purpose is to dynamically filter the predicates in a search form without having to pass all attributes necessary to rebuild the persisted search form.  All specs pass.
