### PR TITLE
Added an option to sort_link to hide the order indicator

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -45,8 +45,8 @@ module Ransack
 
         options = args.first.is_a?(Hash) ? args.shift.dup : {}
         default_order = options.delete :default_order
-        no_order_indicator = options.delete :no_order_indicator
-        current_dir = prev_attr == attr_name && !no_order_indicator ? prev_dir : nil
+        no_order_symbol = options.delete :no_order_symbol
+        current_dir = prev_attr == attr_name ? prev_dir : nil
 
         if current_dir
           new_dir = current_dir == 'desc' ? 'asc' : 'desc'
@@ -67,7 +67,7 @@ module Ransack
           url_for(options)
         end
 
-        link_to [ERB::Util.h(name), order_indicator_for(current_dir)].compact.join(' ').html_safe,
+        link_to [ERB::Util.h(name), (no_order_symbol ? nil : order_indicator_for(current_dir))].compact.join(' ').html_safe,
           url,
           html_options
       end


### PR DESCRIPTION
You can now pass ":no_order_indicator => true" to sort_link parameters, so the &#9650; and &#9660; elements would be hidden.

Cheers ;)
