### PR TITLE
Override `inspect` for @object variable in Ransack::Context

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -25,6 +25,12 @@ module Ransack
       @context.evaluate(self, opts)
     end
 
+    def inspect
+      # Replace the inspect method on object's singleton class to call to_s() instead of to_a().
+      object.class_eval { alias :inspect :to_s }
+      super
+    end
+
     def build(params)
       collapse_multiparameter_attributes!(params).each do |key, value|
         case key


### PR DESCRIPTION
Overrided `inspect` method with `to_s` for `ActiveRecord::Relation` object within `Ransack::Context`, so that `to_a` is not evaluated on the Relation.

By default, calling `inspect()` on a `Search` object would load all records from the table without any conditions. This makes it difficult to work with Ransack from the Rails console, since inspect is called on Ruby objects.
