### PR TITLE
Sort predicate_select keys based on order of :only option

### DIFF
--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -115,16 +115,10 @@ module Ransack
 
       def predicate_select(options = {}, html_options = {})
         options[:compounds] = true if options[:compounds].nil?
-        keys = options[:compounds] ? Predicate.names : Predicate.names.reject {|k| k.match(/_(any|all)$/)}
-        if only = options[:only]
-          if only.respond_to? :call
-            keys = keys.select {|k| only.call(k)}
-          else
-            only = Array.wrap(only).map(&:to_s)
-            keys = keys.select {|k| only.include? k.sub(/_(any|all)$/, '')}
-          end
-        end
-
+        keys = predicate_keys(options)
+        # If condition is newly built with build_condition(),
+        # then replace the default predicate with the first in the ordered list
+        @object.predicate_name = keys.first if @object.default?
         @template.collection_select(
           @object_name, :p, keys.map {|k| [k, Translate.predicate(k)]}, :first, :last,
           objectify_options(options), @default_options.merge(html_options)
@@ -139,6 +133,22 @@ module Ransack
       end
 
       private
+
+      def predicate_keys(options)
+        keys = options[:compounds] ? Predicate.names : Predicate.names.reject {|k| k.match(/_(any|all)$/)}
+        if only = options[:only]
+          if only.respond_to? :call
+            keys = keys.select {|k| only.call(k)}
+          else
+            only = Array.wrap(only).map(&:to_s)
+            # Create compounds hash, e.g. {"eq" => ["eq", "eq_any", "eq_all"], "blank" => ["blank"]}
+            key_groups = keys.inject(Hash.new([])){ |h,k| h[k.sub(/_(any|all)$/, '')] += [k]; h }
+            # Order compounds hash by 'only' keys
+            keys = only.map {|k| key_groups[k] }.flatten.compact
+          end
+        end
+        keys
+      end
 
       def combinator_choices
         if Nodes::Condition === object

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -4,7 +4,8 @@ module Ransack
       i18n_word :attribute, :predicate, :combinator, :value
       i18n_alias :a => :attribute, :p => :predicate, :m => :combinator, :v => :value
 
-      attr_reader :predicate
+      attr_accessor :predicate
+      attr_writer :is_default
 
       class << self
         def extract(context, key, values)
@@ -130,6 +131,10 @@ module Ransack
         false
       end
 
+      def default?
+        @is_default
+      end
+
       def key
         @key ||= attributes.map(&:name).join("_#{combinator}_") + "_#{predicate.name}"
       end
@@ -151,11 +156,6 @@ module Ransack
         self.predicate = Predicate.named(name)
       end
       alias :p= :predicate_name=
-
-      def predicate=(predicate)
-        @predicate = predicate
-        predicate
-      end
 
       def predicate_name
         predicate.name if predicate

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -82,7 +82,8 @@ module Ransack
         attrs = opts[:attributes] || 1
         vals = opts[:values] || 1
         condition = Condition.new(@context)
-        condition.predicate = Predicate.named('eq')
+        condition.predicate_name = opts[:predicate] || 'eq'
+        condition.is_default = true
         attrs.times { condition.build_attribute }
         vals.times { condition.build_value }
         condition

--- a/spec/ransack/helpers/form_builder_spec.rb
+++ b/spec/ransack/helpers/form_builder_spec.rb
@@ -115,6 +115,16 @@ module Ransack
           end
         end
 
+        it 'sorts predicate keys based on order of :only array, with :compounds => false' do
+          ordered_keys = @f.send(:predicate_keys, :compounds => false, :only => [:cont, :blank, :eq, :unknown])
+          ordered_keys.should == %w(cont blank eq)
+        end
+
+        it 'sorts predicate keys based on order of :only array, with :compounds => true' do
+          ordered_keys = @f.send(:predicate_keys, :compounds => true, :only => [:cont, :blank, :eq, :unknown])
+          ordered_keys.should == %w(cont cont_any cont_all blank eq eq_any eq_all)
+        end
+
         it 'excludes compounds when :compounds => false' do
           html = @f.predicate_select :compounds => false
           Predicate.names.select {|k| k =~ /_(any|all)$/}.each do |key|


### PR DESCRIPTION
Sort predicate_select keys based on order of :only option, so that user has the ability to prioritze order of predicates.

I wanted to change the order of predicates in the select list, and was surprised that the following did not have that effect:

``` haml
f.predicate_select :only => [:cont, :not_cont, :matches, :does_not_match, :blank, :present, :eq, :not_eq], :compounds => false
```
