### PR TITLE
remove not anymore existing table_aliases method, instead use alias_tracker

### DIFF
--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -138,7 +138,7 @@ module Ransack
           )
 
           join_nodes.each do |join|
-            join_dependency.table_aliases[join.left.name.downcase] = 1
+            join_dependency.alias_tracker.aliases[join.left.name.downcase] = 1
           end
 
           join_dependency.graft(*stashed_association_joins)


### PR DESCRIPTION
i not sure how to write a test for it. It fixes a bug and i could not find the use table_aliases anywhere in AR. Must be an old method. 
Fixes Issue #35
