### PR TITLE
Ensure that ActiveRecord is required

### DIFF
--- a/lib/ransack/adapters/active_record.rb
+++ b/lib/ransack/adapters/active_record.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'ransack/adapters/active_record/base'
 ActiveRecord::Base.extend Ransack::Adapters::ActiveRecord::Base
 


### PR DESCRIPTION
This is necessary so that gems can have Ransack as a dependency. Otherwise, `rake` tasks throw exceptions like this:

```
** Invoke load_app (first_time)
** Execute load_app
rake aborted!
uninitialized constant Object::ActiveRecord
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/ext/module.rb:36:in `const_missing'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/ransack-0.6.0/lib/ransack/adapters/active_record.rb:2:in `<top (required)>'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/ransack-0.6.0/lib/ransack.rb:22:in `require'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/ransack-0.6.0/lib/ransack.rb:22:in `<top (required)>'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:68:in `require'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:66:in `each'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:66:in `block in require'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:55:in `each'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler/runtime.rb:55:in `require'
/home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.1.rc.7/lib/bundler.rb:118:in `require'
/home/ndbroadbent/code/rails/fat_free_crm/spec/internal/Rakefile:5:in `<top (required)>'
```
