### PR TITLE
Allow adding of custom predicates that take arrays (like IN/NOT IN)

### DIFF
--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -19,6 +19,7 @@ module Ransack
       opts[:name] = name
       compounds = opts.delete(:compounds)
       compounds = true if compounds.nil?
+      compounds = false if opts[:wants_array]
       opts[:arel_predicate] = opts[:arel_predicate].to_s
 
       self.predicates[name] = Predicate.new(opts)

--- a/lib/ransack/predicate.rb
+++ b/lib/ransack/predicate.rb
@@ -41,7 +41,7 @@ module Ransack
       @formatter = opts[:formatter]
       @validator = opts[:validator] || lambda { |v| v.respond_to?(:empty?) ? !v.empty? : !v.nil? }
       @compound = opts[:compound]
-      @wants_array = @compound || ['in', 'not_in'].include?(@arel_predicate)
+      @wants_array = opts[:wants_array] == true || @compound || ['in', 'not_in'].include?(@arel_predicate)
     end
 
     def eql?(other)

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -45,5 +45,15 @@ module Ransack
       # restore original state so we don't break other tests
       Ransack.options = before
     end
+
+    it 'adds predicates that take arrays, overriding compounds' do
+      Ransack.configure do |config|
+        config.add_predicate :test_array_predicate, :wants_array => true, :compounds => true
+      end
+
+      Ransack.predicates['test_array_predicate'].wants_array.should eq true
+      Ransack.predicates.should_not have_key 'test_array_predicate_any'
+      Ransack.predicates.should_not have_key 'test_array_predicate_all'
+    end
   end
 end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -90,6 +90,20 @@ module Ransack
         conditions.should have(2).items
         conditions.map {|c| c.class}.should eq [Nodes::Condition, Nodes::Condition]
       end
+
+      it 'creates Conditions for custom predicates that take arrays' do
+        Ransack.configure do |config|
+          config.add_predicate 'ary_pred',
+          :wants_array => true
+        end
+
+        search = Search.new(Person, :name_ary_pred => ['Ernie', 'Bert'])
+        condition = search.base[:name_ary_pred]
+        condition.should be_a Nodes::Condition
+        condition.predicate.name.should eq 'ary_pred'
+        condition.attributes.first.name.should eq 'name'
+        condition.value.should eq ['Ernie', 'Bert']
+      end
     end
 
     describe '#result' do


### PR DESCRIPTION
Hi,

I realised that the changes I made to your gem and have been using on my own project might come in handy for others: as discussed here: https://github.com/ernie/ransack/issues/11

As discussed in that issue, using matches_any would do the job but cannot be indexed, whereas creating a custom predicate (like we have, called 'ci_in' or 'ci_not_in' to do case insensitive many term matching) can be indexed.  We basically create an index where the terms are upper-cased, and upper-case the search terms before sending them in, and it works quite well - benchmarking proves the indexing is working as the speed is higher than using matches_any.

If you're willing to merge the changes, or provide something similar, it'd be cool.  It'd also be cool if you're not, of course, it's your gem, but I thought I'd run it past you.

Thanks

Asfand Yar Qazi
Team87 HTGT
Sanger Institute
