### PR TITLE
Updated gemspec to point directly at github project

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ernie Miller", "Ryan Bigg"]
   s.email       = ["ernie@erniemiller.org", "radarlistener@gmail.com"]
-  s.homepage    = "http://erniemiller.org/projects/ransack"
+  s.homepage    = "https://github.com/ernie/ransack"
   s.summary     = %q{Object-based searching for ActiveRecord (currently).}
   s.description = %q{Ransack is the successor to the MetaSearch gem. It improves and expands upon MetaSearch's functionality, but does not have a 100%-compatible API.}
 


### PR DESCRIPTION
Can has homepage to go to the Github project? Everytime I want to bring up this gem I have to search Github instead of Rubygems :-(
Or at least put a huge link to the source code on the home page so I can bring it up a little easier.
