### PR TITLE
Fix for #111 InfixOperations breaking count

### DIFF
--- a/lib/ransack/adapters/active_record/compat.rb
+++ b/lib/ransack/adapters/active_record/compat.rb
@@ -1,0 +1,14 @@
+module Arel
+
+  module Visitors
+
+    class DepthFirst < Visitor
+
+      unless method_defined?(:visit_Arel_Nodes_InfixOperation)
+        alias :visit_Arel_Nodes_InfixOperation :binary
+      end
+
+    end
+
+  end
+end

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -1,19 +1,20 @@
 require 'ransack/context'
 require 'ransack/adapters/active_record/3.1/context'
+require 'ransack/adapters/active_record/compat'
 require 'polyamorous'
 
 module Ransack
   module Adapters
     module ActiveRecord
       class Context < ::Ransack::Context
-        
+
         # Redefine a few things that have changed with 3.2.
-        
+
         def initialize(object, options = {})
           super
           @arel_visitor = @engine.connection.visitor
         end
-        
+
         def type_for(attr)
           return nil unless attr && attr.valid?
           name    = attr.arel_attribute.name.to_s
@@ -25,7 +26,7 @@ module Ransack
 
           @engine.connection.schema_cache.columns_hash[table][name].type
         end
-        
+
         def evaluate(search, opts = {})
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
@@ -34,7 +35,7 @@ module Ransack
           end
           opts[:distinct] ? relation.uniq : relation
         end
-        
+
       end
     end
   end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -43,6 +43,11 @@ module Ransack
             s = Person.search(:doubled_name_eq => 'Aric SmithAric Smith')
             s.result.first.should eq Person.find_by_name('Aric Smith')
           end if defined?(Arel::Nodes::InfixOperation)
+
+          it "doesn't break #count if using InfixOperations" do
+            s = Person.search(:doubled_name_eq => 'Aric SmithAric Smith')
+            s.result.count.should eq 1
+          end if defined?(Arel::Nodes::InfixOperation)
         end
 
         describe '#ransackable_attributes' do


### PR DESCRIPTION
Applied method used in Squeel to fix #111 Cannot visit Arel::Nodes::InfixOperation 
