### PR TITLE
Use schema_cache.table_exists? method instead

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -20,11 +20,9 @@ module Ransack
           name    = attr.arel_attribute.name.to_s
           table   = attr.arel_attribute.relation.table_name
 
-          unless @engine.connection.table_exists?(table)
-            raise "No table named #{table} exists"
-          end
-
-          @engine.connection.schema_cache.columns_hash[table][name].type
+          schema_cache = @engine.connection.schema_cache    
+          raise "No table named #{table} exists" unless schema_cache.table_exists?(table)  
+          schema_cache.columns_hash[table][name].type
         end
 
         def evaluate(search, opts = {})


### PR DESCRIPTION
SchemaCache#table_exists? - public API
A cached lookup for table existence.
http://apidock.com/rails/ActiveRecord/ConnectionAdapters/SchemaCache/table_exists%3F
