### PR TITLE
Escape wildcard characters in LIKE clause

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -6,12 +6,12 @@ module Ransack
     AREL_PREDICATES = %w(eq not_eq matches does_not_match lt lteq gt gteq in not_in)
 
     DERIVED_PREDICATES = [
-      ['cont', {:arel_predicate => 'matches', :formatter => proc {|v| "%#{v}%"}}],
-      ['not_cont', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "%#{v}%"}}],
-      ['start', {:arel_predicate => 'matches', :formatter => proc {|v| "#{v}%"}}],
-      ['not_start', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "#{v}%"}}],
-      ['end', {:arel_predicate => 'matches', :formatter => proc {|v| "%#{v}"}}],
-      ['not_end', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "%#{v}"}}],
+      ['cont', {:arel_predicate => 'matches', :formatter => proc {|v| "%#{escape_wildcards(v)}%"}}],
+      ['not_cont', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "%#{escape_wildcards(v)}%"}}],
+      ['start', {:arel_predicate => 'matches', :formatter => proc {|v| "#{escape_wildcards(v)}%"}}],
+      ['not_start', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "#{escape_wildcards(v)}%"}}],
+      ['end', {:arel_predicate => 'matches', :formatter => proc {|v| "%#{escape_wildcards(v)}"}}],
+      ['not_end', {:arel_predicate => 'does_not_match', :formatter => proc {|v| "%#{escape_wildcards(v)}"}}],
       ['true', {:arel_predicate => 'eq', :compounds => false, :type => :boolean, :validator => proc {|v| TRUE_VALUES.include?(v)}}],
       ['false', {:arel_predicate => 'eq', :compounds => false, :type => :boolean, :validator => proc {|v| TRUE_VALUES.include?(v)}, :formatter => proc {|v| !v}}],
       ['present', {:arel_predicate => 'not_eq_all', :compounds => false, :type => :boolean, :validator => proc {|v| TRUE_VALUES.include?(v)}, :formatter => proc {|v| [nil, '']}}],
@@ -19,5 +19,11 @@ module Ransack
       ['null', {:arel_predicate => 'eq', :compounds => false, :type => :boolean, :validator => proc {|v| TRUE_VALUES.include?(v)}, :formatter => proc {|v| nil}}],
       ['not_null', {:arel_predicate => 'not_eq', :compounds => false, :type => :boolean, :validator => proc {|v| TRUE_VALUES.include?(v)}, :formatter => proc {|v| nil}}]
     ]
+
+    module_function
+    # replace % _  \ to \% \_ \\
+    def escape_wildcards(unescaped)
+      unescaped.gsub(/\\/){ "\\\\" }.gsub(/%/, "\\%").gsub(/_/, "\\_")
+    end
   end
 end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -29,6 +29,10 @@ module Ransack
         @s.name_cont = 'ric'
         @s.result.to_sql.should match /"people"."name" LIKE '%ric%'/
       end
+      it 'escapes %, _ and \\ in value' do
+        @s.name_cont = '%_\\'
+        @s.result.to_sql.should match /"people"."name" LIKE '%\\%\\_\\\\%'/
+      end
     end
 
     describe 'not_cont' do


### PR DESCRIPTION
Escape wildcard characters to pass `%_\` as normal (not-wildcard) character in LIKE clause.
