### PR TITLE
Update Ransack::Constants#escape_wildcards

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -23,7 +23,7 @@ module Ransack
     module_function
     # replace % \ to \% \\
     def escape_wildcards(unescaped)
-      unescaped.gsub(/\\/){ "\\\\" }.gsub(/%/, "\\%")
+      unescaped.gsub(/([\\|\%|.])/, '\\\\\\1')
     end
   end
 end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -29,9 +29,9 @@ module Ransack
         @s.name_cont = 'ric'
         @s.result.to_sql.should match /"people"."name" LIKE '%ric%'/
       end
-      it 'escapes % and \\ in value' do
-        @s.name_cont = '%_\\'
-        @s.result.to_sql.should match /"people"."name" LIKE '%\\%_\\\\%'/
+      it 'escapes %, . and \\ in value' do
+        @s.name_cont = '%._\\'
+        @s.result.to_sql.should match /"people"."name" LIKE '%\\%\\._\\\\%'/
       end
     end
 


### PR DESCRIPTION
This pull requests bypasses rails/rails#950. When a string such as  `foo.bar` is used in an ActiveRecord query it is misinterpreted due to eager loading functionality and produces an awfully verbose query. This bypasses this by escaping dots (.) in `LIKE` patterns.

This pull request also reflects commit 71a3938a1c9c4d593b59ac7a0c6296439cd471ad by updating the Predicate spec.

I ran all tests before opening this pull request and can confirm that they all pass.
