### PR TITLE
Reorder results to override orders applied up the chain (eg - scopes)

### DIFF
--- a/lib/ransack/adapters/active_record/3.0/context.rb
+++ b/lib/ransack/adapters/active_record/3.0/context.rb
@@ -20,7 +20,7 @@ module Ransack
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
           if search.sorts.any?
-            relation = relation.except(:order).order(viz.accept(search.sorts))
+            relation = relation.except(:order).reorder(viz.accept(search.sorts))
           end
           opts[:distinct] ? relation.select("DISTINCT #{@klass.quoted_table_name}.*") : relation
         end

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -18,7 +18,7 @@ module Ransack
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
           if search.sorts.any?
-            relation = relation.except(:order).order(viz.accept(search.sorts))
+            relation = relation.except(:order).reorder(viz.accept(search.sorts))
           end
           opts[:distinct] ? relation.select("DISTINCT #{@klass.quoted_table_name}.*") : relation
         end

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -29,7 +29,7 @@ module Ransack
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
           if search.sorts.any?
-            relation = relation.except(:order).order(viz.accept(search.sorts))
+            relation = relation.except(:order).reorder(viz.accept(search.sorts))
           end
           opts[:distinct] ? relation.uniq : relation
         end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -217,6 +217,11 @@ module Ransack
         id_sort.dir.should eq 'desc'
         name_sort.dir.should eq 'asc'
       end
+
+      it 'overrides existing sort' do
+        @s.sorts = 'id asc'
+        @s.result.first.id.should eq 1
+      end
     end
 
     describe '#method_missing' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Base.establish_connection(
 )
 
 class Person < ActiveRecord::Base
+  default_scope order('id DESC')
   belongs_to :parent, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :children, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :articles


### PR DESCRIPTION
If we have:

``` ruby
class Person
   default_scope order('id ASC')
end

search = Search.new(Person)
search.sorts = 'id DESC'
```

Then the sort will not get applied.  We may need to preserve other scopes though, so I've used `reorder` to force replacing any existing order with our sort.

I added a new spec and `default_scope` to `Person`, and all existing specs pass.
