### PR TITLE
Fix errors and warnings with specs on rails 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec
 
 gem 'rake'

--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -23,7 +23,7 @@ module Ransack
       attribute_names = attributes_str.split(/_and_|_or_/)
       combinator = attributes_str.match(/_and_/) ? :and : :or
       defaults = base_ancestors.map do |klass|
-        :"ransack.attributes.#{klass.model_name.underscore}.#{original_name}"
+        :"ransack.attributes.#{klass.model_name.singular}.#{original_name}"
       end
 
       translated_names = attribute_names.map do |attr|
@@ -50,7 +50,7 @@ module Ransack
         raise ArgumentError, "A context is required to translate associations"
       end
 
-      defaults = key.blank? ? [:"#{context.klass.i18n_scope}.models.#{context.klass.model_name.underscore}"] : [:"ransack.associations.#{context.klass.model_name.underscore}.#{key}"]
+      defaults = key.blank? ? [:"#{context.klass.i18n_scope}.models.#{context.klass.model_name.singular}"] : [:"ransack.associations.#{context.klass.model_name.singular}.#{key}"]
       defaults << context.traverse(key).model_name.human
       options = {:count => 1, :default => defaults}
       I18n.translate(defaults.shift, options)
@@ -65,19 +65,19 @@ module Ransack
       interpolations = {}
       interpolations[:attr_fallback_name] = I18n.translate(
         (associated_class ?
-          :"ransack.attributes.#{associated_class.model_name.underscore}.#{attr_name}" :
-          :"ransack.attributes.#{context.klass.model_name.underscore}.#{attr_name}"
+          :"ransack.attributes.#{associated_class.model_name.singular}.#{attr_name}" :
+          :"ransack.attributes.#{context.klass.model_name.singular}.#{attr_name}"
         ),
         :default => [
           (associated_class ?
-            :"#{associated_class.i18n_scope}.attributes.#{associated_class.model_name.underscore}.#{attr_name}" :
-            :"#{context.klass.i18n_scope}.attributes.#{context.klass.model_name.underscore}.#{attr_name}"
+            :"#{associated_class.i18n_scope}.attributes.#{associated_class.model_name.singular}.#{attr_name}" :
+            :"#{context.klass.i18n_scope}.attributes.#{context.klass.model_name.singular}.#{attr_name}"
           ),
           attr_name.humanize
         ]
       )
       defaults = [
-        :"ransack.attributes.#{context.klass.model_name.underscore}.#{name}"
+        :"ransack.attributes.#{context.klass.model_name.singular}.#{name}"
       ]
       if include_associations && associated_class
         defaults << '%{association_name} %{attr_fallback_name}'

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "ransack"
 
-  s.add_dependency 'activerecord', '~> 3.0'
-  s.add_dependency 'actionpack', '~> 3.0'
-  s.add_dependency 'polyamorous', '~> 0.5.0'
+  s.add_dependency 'activerecord'
+  s.add_dependency 'actionpack'
+  s.add_dependency 'polyamorous'
   s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'

--- a/spec/ransack/helpers/form_builder_spec.rb
+++ b/spec/ransack/helpers/form_builder_spec.rb
@@ -7,7 +7,7 @@ module Ransack
       router = ActionDispatch::Routing::RouteSet.new
       router.draw do
         resources :people
-        match ':controller(/:action(/:id(.:format)))'
+        get ':controller(/:action(/:id(.:format)))'
       end
 
       include router.url_helpers

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -7,7 +7,7 @@ module Ransack
       router = ActionDispatch::Routing::RouteSet.new
       router.draw do
         resources :people
-        match ':controller(/:action(/:id(.:format)))'
+        get ':controller(/:action(/:id(.:format)))'
       end
 
       include router.url_helpers


### PR DESCRIPTION
This addresses problems I had running the tests against rails 4.0. There are still deprecation warnings for e.g. `scoped` --> `all`, which should be addressed later in a compatibility-breaking release.
