### PR TITLE
I18n common attributes and Translate.attribute_name

### DIFF
--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -73,6 +73,7 @@ module Ransack
             :"#{associated_class.i18n_scope}.attributes.#{associated_class.model_name.underscore}.#{attr_name}" :
             :"#{context.klass.i18n_scope}.attributes.#{context.klass.model_name.underscore}.#{attr_name}"
           ),
+          :".attributes.#{attr_name}",
           attr_name.humanize
         ]
       )

--- a/spec/ransack/helpers/form_builder_spec.rb
+++ b/spec/ransack/helpers/form_builder_spec.rb
@@ -48,11 +48,17 @@ module Ransack
       end
 
       describe '#sort_link' do
-        subject { @f.sort_link :name, :controller => 'people' }
+        it 'sort_link for ransack attribute' do
+          sort_link = @f.sort_link :name, :controller => 'people'
+          sort_link.should match /people\?q%5Bs%5D=name\+asc/
+          sort_link.should match /sort_link/
+          sort_link.should match /Full Name<\/a>/
+        end
 
-        it { should match /people\?q%5Bs%5D=name\+asc/}
-        it { should match /sort_link/}
-        it { should match /Full Name<\/a>/}
+        it 'sort_link for common attribute' do
+          sort_link = @f.sort_link :id, :controller => 'people'
+          sort_link.should match /id<\/a>/
+        end
       end
 
       describe '#submit' do

--- a/spec/support/en.yml
+++ b/spec/support/en.yml
@@ -1,4 +1,6 @@
 en:
+  attributes:
+    id: 'id'
   ransack:
     attributes:
       person:


### PR DESCRIPTION
I have locale's file:

``` yaml
en:
  # Attributes names common to most models
  attributes:
    name: 'NAME'
  activerecord:
    attributes:
      brand:
```

I get a model's attribute's translation:

``` ruby
1.9.3p125 :011 > Brand.human_attribute_name(:name)
 => "NAME"
```

I have a problem when using `sort_link`. For example, 

``` ruby
sort_link @search, :name, Brand.human_attribute_name(:name) # Translation — NAME. That is ok.
sort_link @search, :name # Translation — Name. Default humanize attribute's translation.
```

I added a new locale's path for translate common attributes to `self.attribute_name`.

`sort_link` give the correct translation now:

``` ruby
sort_link @search, :name # Translation — NAME.
```
