### PR TITLE
Fixes 404 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ernie/ransack.png?branch=master)](https://travis-ci.org/ernie/ransack)
 
-Ransack is a rewrite of [MetaSearch](http://metautonomo.us/projects/metasearch). While it
+Ransack is a rewrite of [MetaSearch](https://github.com/ernie/meta_search). While it
 supports many of the same features as MetaSearch, its underlying implementation differs
 greatly from MetaSearch, and _backwards compatibility is not a design goal._
 


### PR DESCRIPTION
meta_search and squeel link are 404.
I fixed them to github links.
