### PR TITLE
fixes AR4 deprecation warning. 

### DIFF
--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -28,7 +28,7 @@ module Ransack
     end
 
     def initialize(object, options = {})
-      @object = object.scoped
+      @object = object.all
       @klass = @object.klass
       @join_dependency = join_dependency(@object)
       @join_type = options[:join_type] || Arel::OuterJoin


### PR DESCRIPTION
fixes AR4 deprecation warning.

```
DEPRECATION WARNING: Model.scoped is deprecated. Please use Model.all instead.
(called from initialize at lib/ransack/context.rb:31)
```
