### PR TITLE
Remove columns_hash deprecation message

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -22,7 +22,7 @@ module Ransack
 
           schema_cache = @engine.connection.schema_cache    
           raise "No table named #{table} exists" unless schema_cache.table_exists?(table)  
-          schema_cache.columns_hash[table][name].type
+          schema_cache.columns_hash(table)[name].type
         end
 
         def evaluate(search, opts = {})


### PR DESCRIPTION
There were a few changes in syntax, which are followed by annoying deprecation message:
`DEPRECATION WARNING: call columns_hash with a table name!.`
