### PR TITLE
Revert dot scaping in SQL values

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -23,7 +23,7 @@ module Ransack
     module_function
     # replace % \ to \% \\
     def escape_wildcards(unescaped)
-      unescaped.to_s.gsub(/([\\|\%|.])/, '\\\\\\1')
+      unescaped.to_s.gsub(/\\/){ "\\\\" }.gsub(/%/, "\\%")
     end
   end
 end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -12,7 +12,7 @@ module Ransack
         subject.parent_id_cont = 1
         expect { subject.result }.to_not raise_error
       end
-      it "escapes '%', '.' and '\\\\' in value" do
+      it "escapes % and \\ in value" do
         subject.send(:"#{method}=", '%._\\')
         subject.result.to_sql.should match(regexp)
       end
@@ -36,7 +36,7 @@ module Ransack
     end
 
     describe 'cont' do
-      it_has_behavior 'wildcard escaping', :name_cont, /"people"."name" LIKE '%\\%\\._\\\\%'/ do
+      it_has_behavior 'wildcard escaping', :name_cont, /"people"."name" LIKE '%\\%._\\\\%'/ do
         subject { @s }
       end
 
@@ -47,7 +47,7 @@ module Ransack
     end
 
     describe 'not_cont' do
-      it_has_behavior 'wildcard escaping', :name_not_cont, /"people"."name" NOT LIKE '%\\%\\._\\\\%'/ do
+      it_has_behavior 'wildcard escaping', :name_not_cont, /"people"."name" NOT LIKE '%\\%._\\\\%'/ do
         subject { @s }
       end
 


### PR DESCRIPTION
Which was added in #191 to fix a issue present in Rails < 4. However
that fix is no longer necessary since Rails 4 deals properly with dots
in SQL. See these for details:

  https://github.com/rails/rails/issues/9055
  https://github.com/rails/rails/commit/a2dab46

This would be a query generated in Rails 3.2.13

```
"SELECT \"spree_users\".* FROM \"spree_users\"
  WHERE (\"spree_users\".\"email\" LIKE 'spree_commerce@example.com%')"
```

While on Rails 4.0.0.rc1 it would be generated like this:

```
"SELECT \"spree_users\".* FROM \"spree_users\"
  WHERE (\"spree_users\".\"email\" LIKE 'spree_commerce@example\\.com%')"
```

and so return unexpected results

Guys I know very little about regex but I noticed the issue while working on a Spree upgrade and traced the issue down to #191 which took me to the discussions on rails/rails so I believe the change makes sense. I've run the tests against rails 4.0.0.rc1 and everything passes.
