### PR TITLE
Support Rails 4 too

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "ransack"
 
-  s.add_dependency 'activerecord', '~> 3.0'
-  s.add_dependency 'actionpack', '~> 3.0'
+  s.add_dependency 'activerecord', '>= 3.0'
+  s.add_dependency 'actionpack', '>= 3.0'
   s.add_dependency 'polyamorous', '~> 0.6.0'
   s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'machinist', '~> 1.0.6'


### PR DESCRIPTION
Hi,

This makes it possible to use `ransack` when using `rails`'s 4 version.

Best,
