### PR TITLE
fix 'distinct: true' bug

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -20,8 +20,8 @@ module Ransack
           name    = attr.arel_attribute.name.to_s
           table   = attr.arel_attribute.relation.table_name
 
-          schema_cache = @engine.connection.schema_cache    
-          raise "No table named #{table} exists" unless schema_cache.table_exists?(table)  
+          schema_cache = @engine.connection.schema_cache
+          raise "No table named #{table} exists" unless schema_cache.table_exists?(table)
           schema_cache.columns_hash[table][name].type
         end
 
@@ -31,7 +31,13 @@ module Ransack
           if search.sorts.any?
             relation = relation.except(:order).reorder(viz.accept(search.sorts))
           end
-          opts[:distinct] ? relation.uniq : relation
+          if opts[:distinct]
+            uniq_relation = {}
+            relation.each { |court| uniq_relation[court] = court }
+            uniq_relation.keys
+          else
+            relation
+          end
         end
 
       end


### PR DESCRIPTION
-using .uniq caused Active Record errors on search results sorted by associated model's attribute
-changed .uniq to using hash keys to ensure distinctness of results
