### PR TITLE
#sort_link no longer removes params

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -59,11 +59,12 @@ module Ransack
         query_hash = {}
         query_hash[search.context.search_key] = search_params.merge(:s => "#{attr_name} #{new_dir}")
         options.merge!(query_hash)
+        options_for_url = params.merge options
 
         url = if routing_proxy && respond_to?(routing_proxy)
-          send(routing_proxy).url_for(options)
+          send(routing_proxy).url_for(options_for_url)
         else
-          url_for(options)
+          url_for(options_for_url)
         end
 
         link_to [ERB::Util.h(name), order_indicator_for(current_dir)].compact.join(' ').html_safe,

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -45,6 +45,28 @@ module Ransack
 
         it { should match /people\?people_search%5Bs%5D=name\+asc/ }
       end
+
+
+      context 'view has existing parameters' do
+        before do
+          @controller.view_context.params.merge!({exist: 'existing'})
+        end
+        describe '#sort_link should not remove existing params' do
+          subject {
+            @controller.view_context.sort_link(
+              Person.search(
+                {:sorts => ['name desc']},
+                :search_key => 'people_search'
+              ),
+              :name,
+              :controller => 'people'
+            )
+          }
+          it {
+            should match /exist\=existing/
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes an issue with sort_link removing non ransack params from the URL's it generates.

Consider a view that uses two sort/search mechanism: ransack and something else, which works in a similar way. This view uses params[:q] for ransack and params[:r] for the other thing. The controller uses both params to get its collection of records

```
other_search(params[:r]).search(params[:q])
```

Currently sort_link will remove params[:r] thus resetting the other_search, so the two searches can't combine. This small change fixes that.
