### PR TITLE
Fix #158 feature request (remove empty search params from sort_link)

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -14,12 +14,10 @@ module Ransack
              :translate, :to => :base
 
     def initialize(object, params = {}, options = {})
-      params ||= {}
+      (params ||= {}).delete_if { |k, v| v.blank? && v != false }
       @context = Context.for(object, options)
       @context.auth_object = options[:auth_object]
       @base = Nodes::Grouping.new(@context, 'and')
-      params = (params.delete_if { |k, v| v.blank? && v != false }
-        ) if params.present?
       build(params.with_indifferent_access)
     end
 


### PR DESCRIPTION
Shorter sort_link params hash and URL by removing empty search params. 

Fixes issues #158, building on the discussion in PR #207.  

Submitted as a pull request to see if there is interest.
