### PR TITLE
Fixes issue #273 - translations for namespaced models

### DIFF
--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -23,7 +23,7 @@ module Ransack
       attribute_names = attributes_str.split(/_and_|_or_/)
       combinator = attributes_str.match(/_and_/) ? :and : :or
       defaults = base_ancestors.map do |klass|
-        :"ransack.attributes.#{klass.model_name.singular}.#{original_name}"
+        :"ransack.attributes.#{i18n_key(klass)}.#{original_name}"
       end
 
       translated_names = attribute_names.map do |attr|
@@ -50,7 +50,7 @@ module Ransack
         raise ArgumentError, "A context is required to translate associations"
       end
 
-      defaults = key.blank? ? [:"#{context.klass.i18n_scope}.models.#{context.klass.model_name.singular}"] : [:"ransack.associations.#{context.klass.model_name.singular}.#{key}"]
+      defaults = key.blank? ? [:"#{context.klass.i18n_scope}.models.#{i18n_key(context.klass)}"] : [:"ransack.associations.#{i18n_key(context.klass)}.#{key}"]
       defaults << context.traverse(key).model_name.human
       options = {:count => 1, :default => defaults}
       I18n.translate(defaults.shift, options)
@@ -65,20 +65,20 @@ module Ransack
       interpolations = {}
       interpolations[:attr_fallback_name] = I18n.translate(
         (associated_class ?
-          :"ransack.attributes.#{associated_class.model_name.singular}.#{attr_name}" :
-          :"ransack.attributes.#{context.klass.model_name.singular}.#{attr_name}"
+          :"ransack.attributes.#{i18n_key(associated_class)}.#{attr_name}" :
+          :"ransack.attributes.#{i18n_key(context.klass)}.#{attr_name}"
         ),
         :default => [
           (associated_class ?
-            :"#{associated_class.i18n_scope}.attributes.#{associated_class.model_name.singular}.#{attr_name}" :
-            :"#{context.klass.i18n_scope}.attributes.#{context.klass.model_name.singular}.#{attr_name}"
+            :"#{associated_class.i18n_scope}.attributes.#{i18n_key(associated_class)}.#{attr_name}" :
+            :"#{context.klass.i18n_scope}.attributes.#{i18n_key(context.klass)}.#{attr_name}"
           ),
           :".attributes.#{attr_name}",
           attr_name.humanize
         ]
       )
       defaults = [
-        :"ransack.attributes.#{context.klass.model_name.singular}.#{name}"
+        :"ransack.attributes.#{i18n_key(context.klass)}.#{name}"
       ]
       if include_associations && associated_class
         defaults << '%{association_name} %{attr_fallback_name}'
@@ -88,6 +88,14 @@ module Ransack
       end
       options = {:count => 1, :default => defaults}
       I18n.translate(defaults.shift, options.merge(interpolations))
+    end
+
+    def self.i18n_key(klass)
+      if ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR == 0
+        klass.model_name.i18n_key.to_s.tr('.', '/')
+      else
+        klass.model_name.i18n_key.to_s
+      end
     end
   end
 end

--- a/spec/ransack/translate_spec.rb
+++ b/spec/ransack/translate_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module Ransack
+  describe Translate do
+
+    describe '.attribute' do
+      it 'translate namespaced attribute like AR does' do
+        ar_translation = ::Namespace::Article.human_attribute_name(:title)
+        ransack_translation = Ransack::Translate.attribute(:title, :context => ::Namespace::Article.search.context)
+        ransack_translation.should eq ar_translation
+      end
+    end
+  end
+end

--- a/spec/support/en.yml
+++ b/spec/support/en.yml
@@ -5,3 +5,9 @@ en:
     attributes:
       person:
         name: Full Name
+  activerecord:
+    attributes:
+      namespace/article:
+        title: AR Namespaced Title
+      namespace_article:
+        title: Old Ransack Namespaced Title

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -37,6 +37,12 @@ class Article < ActiveRecord::Base
   has_many   :notes, :as => :notable
 end
 
+module Namespace
+  class Article < ::Article
+
+  end
+end
+
 class Comment < ActiveRecord::Base
   belongs_to :article
   belongs_to :person


### PR DESCRIPTION
ActiveRecord uses i18n_key methods which return "namespace/model_name"("namespace.model_name" in rails 3.0.x) for Namespace::ModelName. Ransack should used the same pattern.
