### PR TITLE
ORM agnosticism: remove hard require of ActiveRecord

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -19,7 +19,7 @@ end
 require 'ransack/translate'
 require 'ransack/search'
 require 'ransack/ransacker'
-require 'ransack/adapters/active_record'
+require 'ransack/adapters/active_record' if defined?(::ActiveRecord::Base)
 require 'ransack/helpers'
 require 'action_controller'
 

--- a/lib/ransack/adapters/active_record.rb
+++ b/lib/ransack/adapters/active_record.rb
@@ -1,4 +1,3 @@
-require 'active_record'
 require 'ransack/adapters/active_record/base'
 ActiveRecord::Base.extend Ransack::Adapters::ActiveRecord::Base
 


### PR DESCRIPTION
Do not use `require 'activerecord'`, and instead only load the ransack AR adapters if AR has already been defined.
