### PR TITLE
Fix typo in base_spec

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -23,7 +23,7 @@ module Ransack
           # For infix tests
           def self.sane_adapter?
             case ::ActiveRecord::Base.connection.adapter_name
-              when "SQLite3" || "PostgreSQL"
+              when "SQLite3", "PostgreSQL"
                 true
               else
                 false


### PR DESCRIPTION
I have no idea how important the code in question is; I just saw a typo and thought I'd fix it :cat: 
