### PR TITLE
[299] Let attribute names include "and" / "or"

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -8,7 +8,7 @@ module Ransack
 
       class << self
         def extract(context, key, values)
-          attributes, predicate = extract_attributes_and_predicate(key)
+          attributes, predicate = extract_attributes_and_predicate(context, key)
           if attributes.size > 0
             combinator = key.match(/_(or|and)_/) ? $1 : nil
             condition = self.new(context)
@@ -26,12 +26,12 @@ module Ransack
 
         private
 
-        def extract_attributes_and_predicate(key)
+        def extract_attributes_and_predicate(context, key)
           str = key.dup
           name = Predicate.detect_and_strip_from_string!(str)
           predicate = Predicate.named(name)
           raise ArgumentError, "No valid predicate for #{key}" unless predicate
-          attributes = str.split(/_and_|_or_/)
+          attributes = context.attribute_method?(str) ? [str] : str.split(/_and_|_or_/)
           [attributes, predicate]
         end
       end

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -127,7 +127,8 @@ module Ransack
         when /^(g|c|m|groupings|conditions|combinator)=?$/
           true
         else
-          name.split(/_and_|_or_/).select {|n| !@context.attribute_method?(n)}.empty?
+          @context.attribute_method?(name) ||
+          name.split(/_and_|_or_/).select { |n| !@context.attribute_method?(n) }.empty?
         end
       end
 

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -75,6 +75,12 @@ module Ransack
             s = Person.search(name_cont: "\\WINNER\\")
             s.result.exists?.should be_true
           end
+
+          it "should function correctly when an attribute name has 'and' in it" do
+            p = Person.create!(foo_and_bar: 'qqq')
+            s = Person.search(foo_and_bar_eq: 'qqq')
+            s.result.to_a.should eq [p]
+          end
         end
 
         describe '#ransackable_attributes' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -78,6 +78,7 @@ module Schema
         t.string   :email
         t.integer  :salary
         t.boolean  :awesome, :default => false
+        t.string   :foo_and_bar
         t.timestamps
       end
 


### PR DESCRIPTION
This is my attempt at fixing #299. It works, but likely doesn't cover all scenarios.

The `/_and_|_or_/` style logic exists all over the place; for example I know the translation code is still broken in the context of #299. Maybe it'd be better to extract the attribute splitting logic out to a single method that all code would use.