### PR TITLE
Fix `search` method name clash with other libraries

### DIFF
--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -4,7 +4,7 @@ module Ransack
       module Base
 
         def self.extended(base)
-          alias :search :ransack unless base.method_defined? :search
+          alias :search :ransack unless base.respond_to? :search
           base.class_eval do
             class_attribute :_ransackers
             self._ransackers ||= {}


### PR DESCRIPTION
I kept running in to method name clashes when using Ransack and [ThinkingSphinx](https://github.com/pat/thinking-sphinx) on the same app. They both define a `search` method and I was calling Ransack's when I really wanted TS's.

Then I noticed that Ransack _should be_ accounting for this and not aliasing when AR::Base already has a `search` method defined.

Unfortunately, `method_defined?` returns false here even though TS has already been included in to AR::Base. I'm not sure why (in fact, `method_defined?` even returns false after Ransack is included and aliases itself).

Switching the call to `respond_to?` fixes the problem and the test suite is green. I didn't add a specific test for this because I'm not sure how to test whether or not an alias to a method exists.

I'm happy to add a test with some guidance on how to accomplish it.
