### PR TITLE
Remove direction select control from sort_select form builder

### DIFF
--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -34,8 +34,13 @@ module Ransack
           )
         end
       end
-
+      
       def sort_select(options = {}, html_options = {})
+        sort_attribute_select(options, html_options) +
+        sort_direction_select(options, html_options)
+      end
+
+      def sort_attribute_select(options = {}, html_options = {})
         raise ArgumentError, "sort_select must be called inside a search FormBuilder!" unless object.respond_to?(:context)
         options[:include_blank] = true unless options.has_key?(:include_blank)
         bases = [''] + association_array(options[:associations])
@@ -53,7 +58,7 @@ module Ransack
         end
       end
 
-      def sort_direction(options = {}, html_options = {})
+      def sort_direction_select(options = {}, html_options = {})
         raise ArgumentError, "sort_direction must be called inside a search FormBuilder!" unless object.respond_to?(:context)
         bases = [''] + association_array(options[:associations])
         if bases.size > 1


### PR DESCRIPTION
Remove direction select control from sort_select form builder and put it into its own sort_direction
helper method. This allows the two select controls to be passed different html options so that they may be styled more easily. See [issue 306](https://github.com/activerecord-hackery/ransack/issues/306). The sort_fields block will now look like:

``` erb
<%= f.sort_fields do |s| %>
  <%= s.sort_select %>
  <%= s.sort_direction %>
<% end %>
```
