### PR TITLE
related with #159: remove `respond_to?` from Ransack::Search

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -185,15 +185,9 @@ module Ransack
 
       def strip_predicate_and_index(str)
         string = str.split(/\(/).first
-        string = strip_before_type_cast(string)
         Predicate.detect_and_strip_from_string!(string)
         string
       end
-
-      def strip_before_type_cast(str)
-        str.split("_before_type_cast").first
-      end
-
     end
   end
 end

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -72,14 +72,6 @@ module Ransack
       Nodes::Sort.new(@context).build(opts)
     end
 
-    def respond_to?(method_id, include_private = false)
-      super or begin
-        method_name = method_id.to_s
-        writer = method_name.sub!(/\=$/, '')
-        base.attribute_method?(method_name) ? true : false
-      end
-    end
-
     def method_missing(method_id, *args)
       method_name = method_id.to_s
       writer = method_name.sub!(/\=$/, '')

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -324,12 +324,5 @@ module Ransack
         @s.groupings.first.children_name_eq.should eq 'Ernie'
       end
     end
-
-    describe '#respond_to' do
-      it 'is aware of second argument' do
-        Search.new(Person).respond_to?(:name_eq, true).should be_true
-      end
-    end
-
   end
 end


### PR DESCRIPTION
See conversation https://github.com/activerecord-hackery/ransack/commit/f491cb2ad07fbbf89ac4175785b7a7bfe5c46665#commitcomment-4801999
