### PR TITLE
Allow specifying default attribute and predicate via options[:default]

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -4,7 +4,7 @@ module Ransack
       i18n_word :attribute, :predicate, :combinator, :value
       i18n_alias :a => :attribute, :p => :predicate, :m => :combinator, :v => :value
 
-      attr_reader :predicate
+      attr_accessor :predicate
 
       class << self
         def extract(context, key, values)
@@ -151,11 +151,6 @@ module Ransack
         self.predicate = Predicate.named(name)
       end
       alias :p= :predicate_name=
-
-      def predicate=(predicate)
-        @predicate = predicate
-        predicate
-      end
 
       def predicate_name
         predicate.name if predicate

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -84,7 +84,6 @@ module Ransack
         attrs = opts[:attributes] || 1
         vals = opts[:values] || 1
         condition = Condition.new(@context)
-        condition.predicate = Predicate.named('eq')
         attrs.times { condition.build_attribute }
         vals.times { condition.build_value }
         condition


### PR DESCRIPTION
Affects `predicate_select` and `attribute_select`

Merging this would impact #58, though that's quite a bit out of date now.

I'd like to add specs for this, but I'm struggling to get rspec to behave like Rails does, and the majority of the builder code is already completely untested, so I've not got much to go on.
