### PR TITLE
Allow for hashes with array sorts

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -41,7 +41,11 @@ module Ransack
       case args
       when Array
         args.each do |sort|
-          sort = Nodes::Sort.extract(@context, sort)
+          if sort.kind_of? Hash
+            sort = Nodes::Sort.new(@context).build(sort)
+          else
+            sort = Nodes::Sort.extract(@context, sort)
+          end
           self.sorts << sort
         end
       when Hash

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -241,7 +241,7 @@ module Ransack
       end
 
       it 'creates sorts based on multiple attributes/directions in array format' do
-        @s.sorts = ['id desc', 'name asc']
+        @s.sorts = ['id desc', { :name => 'name', :dir => 'asc' }]
         @s.sorts.should have(2).items
         sort1, sort2 = @s.sorts
         sort1.should be_a Nodes::Sort
@@ -253,7 +253,7 @@ module Ransack
       end
 
       it 'creates sorts based on multiple attributes and uppercase directions in array format' do
-        @s.sorts = ['id DESC', 'name ASC']
+        @s.sorts = ['id DESC', { :name => 'name', :dir => 'ASC' }]
         @s.sorts.should have(2).items
         sort1, sort2 = @s.sorts
         sort1.should be_a Nodes::Sort
@@ -265,7 +265,7 @@ module Ransack
       end
 
       it 'creates sorts based on multiple attributes and different directions in array format' do
-        @s.sorts = ['id DESC', 'name']
+        @s.sorts = ['id DESC', { :name => 'name', :dir => nil }]
         @s.sorts.should have(2).items
         sort1, sort2 = @s.sorts
         sort1.should be_a Nodes::Sort


### PR DESCRIPTION
Sorting with hashes works with hashes of hashes, but fails with array of hashes.  Not sure if this is a bugfix or new feature.

Works:

``` json
    "s": {
      "0":
        {
            "name": "id",
            "dir": "asc"
        },
      "1":
        {
            "name": "name",
            "dir": "asc"
        }
    }
```

Dies:

``` json
    "s": [
        {
            "name": "id",
            "dir": "asc"
        },        
        {
            "name": "name",
            "dir": "asc"
        }
    ]
```
