### PR TITLE
Generate a condition when value is false for boolean predicates

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -55,8 +55,24 @@ module Ransack
         :formatter => proc { |v| true }
         }
       ],
+      ['not_true', {
+        :arel_predicate => proc { |v| v ? 'not_eq' : 'eq' },
+        :compounds => false,
+        :type => :boolean,
+        :validator => proc { |v| BOOLEAN_VALUES.include?(v) },
+        :formatter => proc { |v| true }
+        }
+      ],
       ['false', {
         :arel_predicate => proc { |v| v ? 'eq' : 'not_eq' },
+        :compounds => false,
+        :type => :boolean,
+        :validator => proc { |v| BOOLEAN_VALUES.include?(v) },
+        :formatter => proc { |v| false }
+        }
+      ],
+      ['not_false', {
+        :arel_predicate => proc { |v| v ? 'not_eq' : 'eq' },
         :compounds => false,
         :type => :boolean,
         :validator => proc { |v| BOOLEAN_VALUES.include?(v) },

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -96,6 +96,22 @@ module Ransack
       end
     end
 
+    describe 'not_true' do
+      it 'generates an inequality condition for boolean true' do
+        @s.awesome_not_true = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} != #{
+          ActiveRecord::Base.connection.quoted_true}/
+      end
+
+      it 'generates an equality condition for boolean true' do
+        @s.awesome_not_true = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} = #{
+          ActiveRecord::Base.connection.quoted_true}/
+      end
+    end
+
     describe 'false' do
       it 'generates an equality condition for boolean false' do
         @s.awesome_false = true
@@ -108,6 +124,22 @@ module Ransack
         @s.awesome_false = false
         field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
         expect(@s.result.to_sql).to match /#{field} != #{
+          ActiveRecord::Base.connection.quoted_false}/
+      end
+    end
+
+    describe 'not_false' do
+      it 'generates an inequality condition for boolean false' do
+        @s.awesome_not_false = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} != #{
+          ActiveRecord::Base.connection.quoted_false}/
+      end
+
+      it 'generates an equality condition for boolean false' do
+        @s.awesome_not_false = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} = #{
           ActiveRecord::Base.connection.quoted_false}/
       end
     end


### PR DESCRIPTION
I noticed that for boolean predicates the value `false` is being ignored. This can be counterintuitive as I would expect that `name_present = false` would give me all records where `name` equals `NULL` or is empty.

I found this issue https://github.com/activerecord-hackery/ransack/issues/9 and implemented something starting from @cawel spec.

I am not sure if it is the best approach, but let me know what you think.
