### PR TITLE
Model.search("") should not raise exception

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -14,7 +14,8 @@ module Ransack
              :translate, :to => :base
 
     def initialize(object, params = {}, options = {})
-      (params ||= {}).delete_if { |k, v| v.blank? && v != false }
+      params = {} unless params.is_a?(Hash)
+      params.delete_if { |k, v| v.blank? && v != false }
       @context = Context.for(object, options)
       @context.auth_object = options[:auth_object]
       @base = Nodes::Grouping.new(@context, 'and')

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 module Ransack
   describe Search do
 
+    describe "#initialize" do
+      it "do not raise exception for string :params argument" do
+        lambda { Search.new(Person, "") }.should_not raise_error
+      end
+    end
+
     describe '#build' do
       it 'creates Conditions for top-level attributes' do
         search = Search.new(Person, :name_eq => 'Ernie')


### PR DESCRIPTION
Consider query like:

```
users?q=some-string
```

or

```
users?q=
```

and controller content"

```
User.search(params[:q])
```
