### PR TITLE
Ransack::Search doesn't implement respond_to_missing?

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -78,9 +78,7 @@ module Ransack
     end
 
     def method_missing(method_id, *args)
-      method_name = method_id.to_s
-      writer = method_name.sub!(/\=$/, '')
-      if base.attribute_method?(method_name)
+      if base.attribute_method?(method_id.to_s)
         base.send(method_id, *args)
       else
         super


### PR DESCRIPTION
Incurred into this while doing some hackery (hope to be welcomed here :P ), I'm using a simple delegator to intercept some service selects that won't go in the real search (country/city/location where the only one used in the search is location).

Apart from that `respond_to_missing?` should be there.
