### PR TITLE
guard against nil @associations_pot

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -166,7 +166,7 @@ module Ransack
           found_association = @join_dependency
           .join_root.children.detect do |assoc|
             assoc.reflection.name == name &&
-            @associations_pot[assoc] == parent &&
+            (@associations_pot.nil? || @associations_pot[assoc] == parent) &&
             (!klass || assoc.reflection.klass == klass)
           end
 


### PR DESCRIPTION
I was getting the following error while attempting to upgrade to Rails 4.1:

```
NoMethodError: undefined method `[]' for nil:NilClass
from ~/.rbenv/versions/2.1.0/lib64/ruby/gems/2.1.0/bundler/gems/ransack-d51c78f9071f/lib/ransack/adapters/active_record/context.rb:169:in `block in build_or_find_association'
```

I added a simple guard clause to the condition, since it appears that `@associations_pot` is simply never set until after the first run through this method, though I am not entirely clear on the details.  This seems to fix everything, without breaking the test suite, and my usage of the gem still works.
