### PR TITLE
Add format option to search_form_for

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -5,11 +5,14 @@ module Ransack
       def search_form_for(record, options = {}, &proc)
         if record.is_a?(Ransack::Search)
           search = record
-          options[:url] ||= polymorphic_path(search.klass)
+          options[:url] ||= polymorphic_path(
+            search.klass, format: options.delete(:format)
+            )
         elsif record.is_a?(Array) &&
             (search = record.detect { |o| o.is_a?(Ransack::Search) })
           options[:url] ||= polymorphic_path(
-            record.map { |o| o.is_a?(Ransack::Search) ? o.klass : o }
+            record.map { |o| o.is_a?(Ransack::Search) ? o.klass : o },
+            format: options.delete(:format)
             )
         else
           raise ArgumentError,

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -92,6 +92,24 @@ module Ransack
           }
         end
       end
+
+      describe '#search_form_for with default format' do
+        subject {
+          @controller.view_context.search_form_for(Person.search) {}
+        }
+        it {
+          should match /action="\/people"/
+        }
+      end
+
+      describe '#search_form_for with pdf format' do
+        subject {
+          @controller.view_context.search_form_for(Person.search, format: :pdf) {}
+        }
+        it {
+          should match /action="\/people.pdf"/
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
I wanted to use the format option, but it was not supported.
So I try to fix.
