### PR TITLE
Added polyamorous (1.0.0) back in as a dependency

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 4.0'
   s.add_dependency 'activesupport', '>= 4.0'
   s.add_dependency 'i18n'
-#  s.add_dependency 'polyamorous', '~> 0.6.0'
+  s.add_dependency 'polyamorous', '~> 1.0.0'
   s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'


### PR DESCRIPTION
Not 100% sure, but it looks like polyamorous should be a dependency?

(required in https://github.com/activerecord-hackery/ransack/blob/rails-4.1/lib/ransack/adapters/active_record/context.rb)
