### PR TITLE
[bugfix] don’t crash if blank string is passed to `SomeModel.search` method

### DIFF
--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -12,6 +12,7 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
+          params = params.presence || {}
           Search.new(self, params ? params.delete_if {
             |k, v| v.blank? && v != false } : params, options)
         end

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -45,7 +45,7 @@ module Ransack
         raise TypeError, "First argument must be a Ransack::Search!" unless
           Search === search
 
-        search_params = params[search.context.search_key] ||
+        search_params = params[search.context.search_key].presence ||
           {}.with_indifferent_access
 
         attr_name = attribute.to_s

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -79,6 +79,10 @@ module Ransack
             s = Person.search(nil)
           end
 
+          it "should function correctly when a blank string is passed in" do
+            s = Person.search("")
+          end
+
           it "should function correctly when using fields with dots in them" do
             s = Person.search(:email_cont => "example.com")
             s.result.exists?.should be_true

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -71,6 +71,19 @@ module Ransack
         }
       end
 
+      describe '#sort_link works even if search params are really blank string' do
+        before { @controller.view_context.params[:q] = "" }
+        specify {
+          expect {
+            @controller.view_context.sort_link(
+              Person.search(@controller.view_context.params[:q]),
+              :name,
+              :controller => 'people'
+            )
+          }.not_to raise_error
+        }
+      end
+
       describe '#sort_link with default search_key defined as string' do
         subject {
           @controller.view_context.sort_link(


### PR DESCRIPTION
Little demo:
### URL

`http://localhost:3000/things?q[id_eq]=` (form with Ransack filter was submitted without selecting any value in it)
### Controller

```
# params == {q: {id_eq: ""}}
@q = Thing.search(params[:q])
# params == {q: {}} (because of `params.delete_if ...`)
```
### Any view that uses `params[:q]` (for example paginator)

```
= link_to "Page 2", url_for(params.merge(page: 2)) # produces http://localhost:3000/things?q=&page=2
```

Bug was introduced when that PR were accepted:
https://github.com/rails/rails/pull/13909
