### PR TITLE
Ignore conditions without a predicate (instead of raising an error)

### DIFF
--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -6,7 +6,10 @@ module Ransack
 
     mattr_accessor :predicates, :options
     self.predicates = {}
-    self.options = { :search_key => :q }
+    self.options = {
+      :search_key => :q,
+      :ignore_unknown_conditions => true
+    }
 
     def configure
       yield self
@@ -38,6 +41,11 @@ module Ransack
     # default search_key that, it can be overridden on sort_link level
     def search_key=(name)
       self.options[:search_key] = name
+    end
+
+    # raise an error if an unknown attribute is passed into a search
+    def ignore_unknown_conditions=(boolean)
+      self.options[:ignore_unknown_conditions] = boolean
     end
 
     def arel_predicate_with_suffix(arel_predicate, suffix)

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -35,6 +35,9 @@ module Ransack
           str = key.dup
           name = Predicate.detect_and_strip_from_string!(str)
           predicate = Predicate.named(name)
+          if predicate.nil? && !Ransack.options[:ignore_unknown_conditions]
+            raise ArgumentError, "No valid predicate for #{key}"
+          end
           attributes = str.split(/_and_|_or_/)
           [attributes, predicate]
         end

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -29,11 +29,12 @@ module Ransack
 
     def build(params)
       collapse_multiparameter_attributes!(params).each do |key, value|
-        case key
-        when 's', 'sorts'
+        if ['s', 'sorts'].include?(key)
           send("#{key}=", value)
-        else
-          base.send("#{key}=", value) if base.attribute_method?(key)
+        elsif base.attribute_method?(key)
+          base.send("#{key}=", value)
+        elsif !Ransack.options[:ignore_unknown_conditions]
+          raise ArgumentError, "Invalid search term #{key}"
         end
       end
       self

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -12,7 +12,22 @@ module Ransack
 
       context 'with an invalid predicate' do
         subject { Condition.extract(Context.for(Person), 'name_invalid', Person.first.name) }
-        specify { subject.should be_nil }
+
+        context "when ignore_unknown_conditions is false" do
+          before do
+            Ransack.configure { |config| config.ignore_unknown_conditions = false }
+          end
+
+          specify { expect { subject }.to raise_error ArgumentError }
+        end
+
+        context "when ignore_unknown_conditions is true" do
+          before do
+            Ransack.configure { |config| config.ignore_unknown_conditions = true }
+          end
+
+          specify { subject.should be_nil }
+        end
       end
     end
   end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -147,6 +147,26 @@ module Ransack
         search = Search.new(Person, :children_id_in => [1, 2, 3])
         search.inspect.should_not match /ActiveRecord/
       end
+
+      context 'with an invalid condition' do
+        subject { Search.new(Person, :unknown_attr_eq => 'Ernie') }
+
+        context "when ignore_unknown_conditions is false" do
+          before do
+            Ransack.configure { |config| config.ignore_unknown_conditions = false }
+          end
+
+          specify { expect { subject }.to raise_error ArgumentError }
+        end
+
+        context "when ignore_unknown_conditions is true" do
+          before do
+            Ransack.configure { |config| config.ignore_unknown_conditions = true }
+          end
+
+          specify { expect { subject }.to_not raise_error ArgumentError }
+        end
+      end
     end
 
     describe '#result' do


### PR DESCRIPTION
We're seeing a few `No valid predicate for ...` errors from our support staff trying to manually edit the query strings in our searches.

To solve the above we're cleaning the params before passing them through to Ransack, but it would be nicer if Ransack just ignored these badly-specified conditions, in the same way it ignores terms which don't relate to an attribute.
