### PR TITLE
RSpec Updates

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'i18n'
   s.add_dependency 'polyamorous', '~> 1.0.0'
-  s.add_development_dependency 'rspec', '~> 2.8.0'
+  s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'
   s.add_development_dependency 'sqlite3', '~> 1.3.3'

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -15,7 +15,7 @@ module Ransack
 
           it { should be_a Search }
           it 'has a Relation as its object' do
-            subject.object.should be_an ::ActiveRecord::Relation
+            expect(subject.object).to be_an ::ActiveRecord::Relation
           end
         end
 
@@ -42,14 +42,14 @@ module Ransack
 
           it 'creates ransack attributes' do
             s = Person.search(:reversed_name_eq => 'htimS cirA')
-            s.result.should have(1).person
+            expect(s.result.size).to eq(1)
 
-            s.result.first.should eq Person.where(name: 'Aric Smith').first
+            expect(s.result.first).to eq Person.where(name: 'Aric Smith').first
           end
 
           it 'can be accessed through associations' do
             s = Person.search(:children_reversed_name_eq => 'htimS cirA')
-            s.result.to_sql.should match(
+            expect(s.result.to_sql).to match(
               /#{quote_table_name("children_people")}.#{
                  quote_column_name("name")} = 'Aric Smith'/
             )
@@ -57,22 +57,22 @@ module Ransack
 
           it 'allows an "attribute" to be an InfixOperation' do
             s = Person.search(:doubled_name_eq => 'Aric SmithAric Smith')
-            s.result.first.should eq Person.where(name: 'Aric Smith').first
+            expect(s.result.first).to eq Person.where(name: 'Aric Smith').first
           end if defined?(Arel::Nodes::InfixOperation) && sane_adapter?
 
           it "doesn't break #count if using InfixOperations" do
             s = Person.search(:doubled_name_eq => 'Aric SmithAric Smith')
-            s.result.count.should eq 1
+            expect(s.result.count).to eq 1
           end if defined?(Arel::Nodes::InfixOperation) && sane_adapter?
 
           it "should remove empty key value pairs from the params hash" do
             s = Person.search(:children_reversed_name_eq => '')
-            s.result.to_sql.should_not match /LEFT OUTER JOIN/
+            expect(s.result.to_sql).not_to match /LEFT OUTER JOIN/
           end
 
           it "should keep proper key value pairs in the params hash" do
             s = Person.search(:children_reversed_name_eq => 'Testing')
-            s.result.to_sql.should match /LEFT OUTER JOIN/
+            expect(s.result.to_sql).to match /LEFT OUTER JOIN/
           end
 
           it "should function correctly when nil is passed in" do
@@ -85,26 +85,26 @@ module Ransack
 
           it "should function correctly when using fields with dots in them" do
             s = Person.search(:email_cont => "example.com")
-            s.result.exists?.should be_true
+            expect(s.result.exists?).to be_true
           end
 
           it "should function correctly when using fields with % in them" do
             Person.create!(:name => "110%-er")
             s = Person.search(:name_cont => "10%")
-            s.result.exists?.should be_true
+            expect(s.result.exists?).to be_true
           end
 
           it "should function correctly when using fields with backslashes in them" do
             Person.create!(:name => "\\WINNER\\")
             s = Person.search(:name_cont => "\\WINNER\\")
-            s.result.exists?.should be_true
+            expect(s.result.exists?).to be_true
           end
 
           it 'allows sort by "only_sort" field' do
             s = Person.search(
               "s" => { "0" => { "dir" => "asc", "name" => "only_sort" } }
             )
-            s.result.to_sql.should match(
+            expect(s.result.to_sql).to match(
               /ORDER BY #{quote_table_name("people")}.#{
                 quote_column_name("only_sort")} ASC/
             )
@@ -114,7 +114,7 @@ module Ransack
             s = Person.search(
               "s" => { "0" => { "dir" => "asc", "name" => "only_search" } }
             )
-            s.result.to_sql.should_not match(
+            expect(s.result.to_sql).not_to match(
               /ORDER BY #{quote_table_name("people")}.#{
                 quote_column_name("only_search")} ASC/
             )
@@ -122,7 +122,7 @@ module Ransack
 
           it 'allows search by "only_search" field' do
             s = Person.search(:only_search_eq => 'htimS cirA')
-            s.result.to_sql.should match(
+            expect(s.result.to_sql).to match(
               /WHERE #{quote_table_name("people")}.#{
                 quote_column_name("only_search")} = 'htimS cirA'/
             )
@@ -130,7 +130,7 @@ module Ransack
 
           it "can't be searched by 'only_sort'" do
             s = Person.search(:only_sort_eq => 'htimS cirA')
-            s.result.to_sql.should_not match(
+            expect(s.result.to_sql).not_to match(
               /WHERE #{quote_table_name("people")}.#{
                 quote_column_name("only_sort")} = 'htimS cirA'/
             )
@@ -141,7 +141,7 @@ module Ransack
               { "s" => { "0" => { "dir" => "asc", "name" => "only_admin" } } },
               { auth_object: :admin }
             )
-            s.result.to_sql.should match(
+            expect(s.result.to_sql).to match(
               /ORDER BY #{quote_table_name("people")}.#{
                 quote_column_name("only_admin")} ASC/
             )
@@ -151,7 +151,7 @@ module Ransack
             s = Person.search(
               "s" => { "0" => { "dir" => "asc", "name" => "only_admin" } }
             )
-            s.result.to_sql.should_not match(
+            expect(s.result.to_sql).not_to match(
               /ORDER BY #{quote_table_name("people")}.#{
                 quote_column_name("only_admin")} ASC/
             )
@@ -162,7 +162,7 @@ module Ransack
               { :only_admin_eq => 'htimS cirA' },
               { :auth_object => :admin }
             )
-            s.result.to_sql.should match(
+            expect(s.result.to_sql).to match(
               /WHERE #{quote_table_name("people")}.#{
                 quote_column_name("only_admin")} = 'htimS cirA'/
             )
@@ -170,7 +170,7 @@ module Ransack
 
           it "can't be searched by 'only_admin', if auth_object: nil" do
             s = Person.search(:only_admin_eq => 'htimS cirA')
-            s.result.to_sql.should_not match(
+            expect(s.result.to_sql).not_to match(
               /WHERE #{quote_table_name("people")}.#{
                 quote_column_name("only_admin")} = 'htimS cirA'/
             )

--- a/spec/ransack/adapters/active_record/context_spec.rb
+++ b/spec/ransack/adapters/active_record/context_spec.rb
@@ -8,7 +8,7 @@ module Ransack
 
         describe '#relation_for' do
           it 'returns relation for given object' do
-            subject.object.should be_an ::ActiveRecord::Relation
+            expect(subject.object).to be_an ::ActiveRecord::Relation
           end
         end
 
@@ -17,32 +17,32 @@ module Ransack
             search = Search.new(Person, :name_eq => 'Joe Blow')
             result = subject.evaluate(search)
 
-            result.should be_an ::ActiveRecord::Relation
-            result.to_sql.should match /#{quote_column_name("name")} = 'Joe Blow'/
+            expect(result).to be_an ::ActiveRecord::Relation
+            expect(result.to_sql).to match /#{quote_column_name("name")} = 'Joe Blow'/
           end
 
           it 'SELECTs DISTINCT when distinct: true' do
             search = Search.new(Person, :name_eq => 'Joe Blow')
             result = subject.evaluate(search, :distinct => true)
 
-            result.should be_an ::ActiveRecord::Relation
-            result.to_sql.should match /SELECT DISTINCT/
+            expect(result).to be_an ::ActiveRecord::Relation
+            expect(result.to_sql).to match /SELECT DISTINCT/
           end
         end
 
         it 'contextualizes strings to attributes' do
           attribute = subject.contextualize 'children_children_parent_name'
-          attribute.should be_a Arel::Attributes::Attribute
-          attribute.name.to_s.should eq 'name'
-          attribute.relation.table_alias.should eq 'parents_people'
+          expect(attribute).to be_a Arel::Attributes::Attribute
+          expect(attribute.name.to_s).to eq 'name'
+          expect(attribute.relation.table_alias).to eq 'parents_people'
         end
 
         it 'builds new associations if not yet built' do
           attribute = subject.contextualize 'children_articles_title'
-          attribute.should be_a Arel::Attributes::Attribute
-          attribute.name.to_s.should eq 'title'
-          attribute.relation.name.should eq 'articles'
-          attribute.relation.table_alias.should be_nil
+          expect(attribute).to be_a Arel::Attributes::Attribute
+          expect(attribute.name.to_s).to eq 'title'
+          expect(attribute.relation.name).to eq 'articles'
+          expect(attribute.relation.table_alias).to be_nil
         end
 
       end

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -4,7 +4,7 @@ module Ransack
   describe Configuration do
     it 'yields Ransack on configure' do
       Ransack.configure do |config|
-        config.should eq Ransack
+        expect(config).to eq Ransack
       end
     end
 
@@ -13,9 +13,9 @@ module Ransack
         config.add_predicate :test_predicate
       end
 
-      Ransack.predicates.should have_key 'test_predicate'
-      Ransack.predicates.should have_key 'test_predicate_any'
-      Ransack.predicates.should have_key 'test_predicate_all'
+      expect(Ransack.predicates).to have_key 'test_predicate'
+      expect(Ransack.predicates).to have_key 'test_predicate_any'
+      expect(Ransack.predicates).to have_key 'test_predicate_all'
     end
 
     it 'avoids creating compound predicates if compounds: false' do
@@ -25,16 +25,16 @@ module Ransack
           :compounds => false
           )
       end
-      Ransack.predicates
-      .should have_key 'test_predicate_without_compound'
-      Ransack.predicates
-      .should_not have_key 'test_predicate_without_compound_any'
-      Ransack.predicates
-      .should_not have_key 'test_predicate_without_compound_all'
+      expect(Ransack.predicates)
+      .to have_key 'test_predicate_without_compound'
+      expect(Ransack.predicates)
+      .not_to have_key 'test_predicate_without_compound_any'
+      expect(Ransack.predicates)
+      .not_to have_key 'test_predicate_without_compound_all'
     end
 
     it 'should have default value for search key' do
-      Ransack.options[:search_key].should eq :q
+      expect(Ransack.options[:search_key]).to eq :q
     end
 
     it 'changes default search key parameter' do
@@ -45,7 +45,7 @@ module Ransack
         config.search_key = :query
       end
 
-      Ransack.options[:search_key].should eq :query
+      expect(Ransack.options[:search_key]).to eq :query
 
       # restore original state so we don't break other tests
       Ransack.options = before
@@ -60,9 +60,9 @@ module Ransack
           )
       end
 
-      Ransack.predicates['test_array_predicate'].wants_array.should eq true
-      Ransack.predicates.should_not have_key 'test_array_predicate_any'
-      Ransack.predicates.should_not have_key 'test_array_predicate_all'
+      expect(Ransack.predicates['test_array_predicate'].wants_array).to eq true
+      expect(Ransack.predicates).not_to have_key 'test_array_predicate_any'
+      expect(Ransack.predicates).not_to have_key 'test_array_predicate_all'
     end
   end
 end

--- a/spec/ransack/dependencies_spec.rb
+++ b/spec/ransack/dependencies_spec.rb
@@ -2,7 +2,7 @@ unless ::ActiveRecord::VERSION::STRING >= '4'
   describe 'Ransack' do
     it 'can be required without errors' do
       output = `bundle exec ruby -e "require 'ransack'" 2>&1`
-      output.should be_empty
+      expect(output).to be_empty
     end
   end
 end

--- a/spec/ransack/helpers/form_builder_spec.rb
+++ b/spec/ransack/helpers/form_builder_spec.rb
@@ -39,7 +39,7 @@ module Ransack
           :include_seconds => true
           )
         %w(2011 1 2 03 04 05).each do |val|
-          html.should match /<option selected="selected" value="#{val}">#{val}<\/option>/
+          expect(html).to match /<option selected="selected" value="#{val}">#{val}<\/option>/
         end
       end
 
@@ -47,7 +47,7 @@ module Ransack
 
         it 'localizes attribute names' do
           html = @f.label :name_cont
-          html.should match /Full Name contains/
+          expect(html).to match /Full Name contains/
         end
 
       end
@@ -56,17 +56,17 @@ module Ransack
         it 'sort_link for ransack attribute' do
           sort_link = @f.sort_link :name, :controller => 'people'
           if ActiveRecord::VERSION::STRING =~ /^3\.[1-2]\./
-            sort_link.should match /people\?q%5Bs%5D=name\+asc/
+            expect(sort_link).to match /people\?q%5Bs%5D=name\+asc/
           else
-            sort_link.should match /people\?q(%5B|\[)s(%5D|\])=name\+asc/
+            expect(sort_link).to match /people\?q(%5B|\[)s(%5D|\])=name\+asc/
           end
-          sort_link.should match /sort_link/
-          sort_link.should match /Full Name<\/a>/
+          expect(sort_link).to match /sort_link/
+          expect(sort_link).to match /Full Name<\/a>/
         end
 
         it 'sort_link for common attribute' do
           sort_link = @f.sort_link :id, :controller => 'people'
-          sort_link.should match /id<\/a>/
+          expect(sort_link).to match /id<\/a>/
         end
       end
 
@@ -74,7 +74,7 @@ module Ransack
 
         it 'localizes :search when no default value given' do
           html = @f.submit
-          html.should match /"Search"/
+          expect(html).to match /"Search"/
         end
 
       end
@@ -83,10 +83,10 @@ module Ransack
 
         it 'returns ransackable attributes' do
           html = @f.attribute_select
-          html.split(/\n/).
-            should have(Person.ransackable_attributes.size + 1).lines
+          expect(html.split(/\n/).size).
+            to eq(Person.ransackable_attributes.size + 1)
           Person.ransackable_attributes.each do |attribute|
-            html.should match /<option value="#{attribute}">/
+            expect(html).to match /<option value="#{attribute}">/
           end
         end
 
@@ -94,16 +94,16 @@ module Ransack
           attributes = Person.ransackable_attributes + Article.
             ransackable_attributes.map { |a| "articles_#{a}" }
           html = @f.attribute_select(:associations => ['articles'])
-          html.split(/\n/).should have(attributes.size).lines
+          expect(html.split(/\n/).size).to eq(attributes.size)
           attributes.each do |attribute|
-            html.should match /<option value="#{attribute}">/
+            expect(html).to match /<option value="#{attribute}">/
           end
         end
 
         it 'returns option groups for base and associations with :associations' do
           html = @f.attribute_select(:associations => ['articles'])
           [Person, Article].each do |model|
-            html.should match /<optgroup label="#{model}">/
+            expect(html).to match /<optgroup label="#{model}">/
           end
         end
 
@@ -114,28 +114,28 @@ module Ransack
         it 'returns predicates with predicate_select' do
           html = @f.predicate_select
           Predicate.names.each do |key|
-            html.should match /<option value="#{key}">/
+            expect(html).to match /<option value="#{key}">/
           end
         end
 
         it 'filters predicates with single-value :only' do
           html = @f.predicate_select :only => 'eq'
           Predicate.names.reject { |k| k =~ /^eq/ }.each do |key|
-            html.should_not match /<option value="#{key}">/
+            expect(html).not_to match /<option value="#{key}">/
           end
         end
 
         it 'filters predicates with multi-value :only' do
           html = @f.predicate_select only: [:eq, :lt]
           Predicate.names.reject { |k| k =~ /^(eq|lt)/ }.each do |key|
-            html.should_not match /<option value="#{key}">/
+            expect(html).not_to match /<option value="#{key}">/
           end
         end
 
         it 'excludes compounds when compounds: false' do
           html = @f.predicate_select :compounds => false
           Predicate.names.select { |k| k =~ /_(any|all)$/ }.each do |key|
-            html.should_not match /<option value="#{key}">/
+            expect(html).not_to match /<option value="#{key}">/
           end
         end
       end
@@ -148,11 +148,11 @@ module Ransack
         end
         it 'accepts poly_id field' do
           html = @f.text_field(:notable_id_eq)
-          html.should match /id=\"q_notable_id_eq\"/
+          expect(html).to match /id=\"q_notable_id_eq\"/
         end
         it 'accepts poly_type field' do
           html = @f.text_field(:notable_type_eq)
-          html.should match /id=\"q_notable_type_eq\"/
+          expect(html).to match /id=\"q_notable_type_eq\"/
         end
       end
     end

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -7,7 +7,7 @@ module Ransack
       context 'with multiple values and an _any predicate' do
         subject { Condition.extract(Context.for(Person), 'name_eq_any', Person.first(2).map(&:name)) }
 
-        specify { subject.values.should have(2).values }
+        specify { expect(subject.values.size).to eq(2) }
       end
 
     end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -15,7 +15,7 @@ module Ransack
 
       it "escapes '%', '.' and '\\\\' in value" do
         subject.send(:"#{method}=", '%._\\')
-        subject.result.to_sql.should match(regexp)
+        expect(subject.result.to_sql).to match(regexp)
       end
     end
 
@@ -24,20 +24,20 @@ module Ransack
         @s.awesome_eq = true
         field = "#{quote_table_name("people")}.#{
           quote_column_name("awesome")}"
-        @s.result.to_sql.should match /#{field} = #{
+        expect(@s.result.to_sql).to match /#{field} = #{
           ActiveRecord::Base.connection.quoted_true}/
       end
 
       it 'generates an equality condition for boolean false' do
         @s.awesome_eq = false
         field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
-        @s.result.to_sql.should match /#{field} = #{
+        expect(@s.result.to_sql).to match /#{field} = #{
           ActiveRecord::Base.connection.quoted_false}/
       end
 
       it 'does not generate a condition for nil' do
         @s.awesome_eq = nil
-        @s.result.to_sql.should_not match /WHERE/
+        expect(@s.result.to_sql).not_to match /WHERE/
       end
     end
 
@@ -57,7 +57,7 @@ module Ransack
       it 'generates a LIKE query with value surrounded by %' do
         @s.name_cont = 'ric'
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} I?LIKE '%ric%'/
+        expect(@s.result.to_sql).to match /#{field} I?LIKE '%ric%'/
       end
     end
 
@@ -76,7 +76,7 @@ module Ransack
       it 'generates a NOT LIKE query with value surrounded by %' do
         @s.name_not_cont = 'ric'
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} NOT I?LIKE '%ric%'/
+        expect(@s.result.to_sql).to match /#{field} NOT I?LIKE '%ric%'/
       end
     end
 
@@ -84,13 +84,13 @@ module Ransack
       it 'generates a value IS NULL query' do
         @s.name_null = true
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NULL/
+        expect(@s.result.to_sql).to match /#{field} IS NULL/
       end
 
       it 'generates a value IS NOT NULL query when assigned false' do
         @s.name_null = false
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NOT NULL/
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL/
       end
     end
 
@@ -98,13 +98,13 @@ module Ransack
       it 'generates a value IS NOT NULL query' do
         @s.name_not_null = true
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NOT NULL/
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL/
       end
 
       it 'generates a value IS NULL query when assigned false' do
         @s.name_not_null = false
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NULL/
+        expect(@s.result.to_sql).to match /#{field} IS NULL/
       end
     end
 
@@ -112,13 +112,13 @@ module Ransack
       it %q[generates a value IS NOT NULL AND value != '' query] do
         @s.name_present = true
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NOT NULL AND #{field} != ''/
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL AND #{field} != ''/
       end
 
       it %q[generates a value IS NULL OR value = '' query when assigned false] do
         @s.name_present = false
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NULL OR #{field} = ''/
+        expect(@s.result.to_sql).to match /#{field} IS NULL OR #{field} = ''/
       end
     end
 
@@ -126,13 +126,13 @@ module Ransack
       it %q[generates a value IS NULL OR value = '' query] do
         @s.name_blank = true
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NULL OR #{field} = ''/
+        expect(@s.result.to_sql).to match /#{field} IS NULL OR #{field} = ''/
       end
 
       it %q[generates a value IS NOT NULL AND value != '' query when assigned false] do
         @s.name_blank = false
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
-        @s.result.to_sql.should match /#{field} IS NOT NULL AND #{field} != ''/
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL AND #{field} != ''/
       end
     end
   end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -4,37 +4,37 @@ module Ransack
   describe Search do
     describe '#initialize' do
       it "removes empty conditions before building" do
-        Search.any_instance.should_receive(:build).with({})
+        expect_any_instance_of(Search).to receive(:build).with({})
         Search.new(Person, :name_eq => '')
       end
 
       it "keeps conditions with a false value before building" do
-        Search.any_instance.should_receive(:build).with({"name_eq" => false})
+        expect_any_instance_of(Search).to receive(:build).with({"name_eq" => false})
         Search.new(Person, :name_eq => false)
       end
 
       it "keeps conditions with a value before building" do
-        Search.any_instance.should_receive(:build).with({"name_eq" => 'foobar'})
+        expect_any_instance_of(Search).to receive(:build).with({"name_eq" => 'foobar'})
         Search.new(Person, :name_eq => 'foobar')
       end
 
       it "removes empty suffixed conditions before building" do
-        Search.any_instance.should_receive(:build).with({})
+        expect_any_instance_of(Search).to receive(:build).with({})
         Search.new(Person, :name_eq_any => [''])
       end
 
       it "keeps suffixed conditions with a false value before building" do
-        Search.any_instance.should_receive(:build).with({"name_eq_any" => [false]})
+        expect_any_instance_of(Search).to receive(:build).with({"name_eq_any" => [false]})
         Search.new(Person, :name_eq_any => [false])
       end
 
       it "keeps suffixed conditions with a value before building" do
-        Search.any_instance.should_receive(:build).with({"name_eq_any" => ['foobar']})
+        expect_any_instance_of(Search).to receive(:build).with({"name_eq_any" => ['foobar']})
         Search.new(Person, :name_eq_any => ['foobar'])
       end
 
       it 'does not raise exception for string :params argument' do
-        lambda { Search.new(Person, '') }.should_not raise_error
+        expect { Search.new(Person, '') }.not_to raise_error
       end
     end
 
@@ -42,28 +42,28 @@ module Ransack
       it 'creates conditions for top-level attributes' do
         search = Search.new(Person, :name_eq => 'Ernie')
         condition = search.base[:name_eq]
-        condition.should be_a Nodes::Condition
-        condition.predicate.name.should eq 'eq'
-        condition.attributes.first.name.should eq 'name'
-        condition.value.should eq 'Ernie'
+        expect(condition).to be_a Nodes::Condition
+        expect(condition.predicate.name).to eq 'eq'
+        expect(condition.attributes.first.name).to eq 'name'
+        expect(condition.value).to eq 'Ernie'
       end
 
       it 'creates conditions for association attributes' do
         search = Search.new(Person, :children_name_eq => 'Ernie')
         condition = search.base[:children_name_eq]
-        condition.should be_a Nodes::Condition
-        condition.predicate.name.should eq 'eq'
-        condition.attributes.first.name.should eq 'children_name'
-        condition.value.should eq 'Ernie'
+        expect(condition).to be_a Nodes::Condition
+        expect(condition.predicate.name).to eq 'eq'
+        expect(condition.attributes.first.name).to eq 'children_name'
+        expect(condition.value).to eq 'Ernie'
       end
 
       it 'creates conditions for polymorphic belongs_to association attributes' do
         search = Search.new(Note, :notable_of_Person_type_name_eq => 'Ernie')
         condition = search.base[:notable_of_Person_type_name_eq]
-        condition.should be_a Nodes::Condition
-        condition.predicate.name.should eq 'eq'
-        condition.attributes.first.name.should eq 'notable_of_Person_type_name'
-        condition.value.should eq 'Ernie'
+        expect(condition).to be_a Nodes::Condition
+        expect(condition.predicate.name).to eq 'eq'
+        expect(condition.attributes.first.name).to eq 'notable_of_Person_type_name'
+        expect(condition.value).to eq 'Ernie'
       end
 
       it 'creates conditions for multiple polymorphic belongs_to association attributes' do
@@ -71,17 +71,17 @@ module Ransack
           :notable_of_Person_type_name_or_notable_of_Article_type_title_eq => 'Ernie')
         condition = search.
           base[:notable_of_Person_type_name_or_notable_of_Article_type_title_eq]
-        condition.should be_a Nodes::Condition
-        condition.predicate.name.should eq 'eq'
-        condition.attributes.first.name.should eq 'notable_of_Person_type_name'
-        condition.attributes.last.name.should eq 'notable_of_Article_type_title'
-        condition.value.should eq 'Ernie'
+        expect(condition).to be_a Nodes::Condition
+        expect(condition.predicate.name).to eq 'eq'
+        expect(condition.attributes.first.name).to eq 'notable_of_Person_type_name'
+        expect(condition.attributes.last.name).to eq 'notable_of_Article_type_title'
+        expect(condition.value).to eq 'Ernie'
       end
 
       it 'discards empty conditions' do
         search = Search.new(Person, :children_name_eq => '')
         condition = search.base[:children_name_eq]
-        condition.should be_nil
+        expect(condition).to be_nil
       end
 
       it 'accepts arrays of groupings' do
@@ -92,12 +92,12 @@ module Ransack
           ]
         )
         ors = search.groupings
-        ors.should have(2).items
+        expect(ors.size).to eq(2)
         or1, or2 = ors
-        or1.should be_a Nodes::Grouping
-        or1.combinator.should eq 'or'
-        or2.should be_a Nodes::Grouping
-        or2.combinator.should eq 'or'
+        expect(or1).to be_a Nodes::Grouping
+        expect(or1.combinator).to eq 'or'
+        expect(or2).to be_a Nodes::Grouping
+        expect(or2.combinator).to eq 'or'
       end
 
       it 'accepts "attributes" hashes for groupings' do
@@ -108,12 +108,12 @@ module Ransack
           }
         )
         ors = search.groupings
-        ors.should have(2).items
+        expect(ors.size).to eq(2)
         or1, or2 = ors
-        or1.should be_a Nodes::Grouping
-        or1.combinator.should eq 'or'
-        or2.should be_a Nodes::Grouping
-        or2.combinator.should eq 'or'
+        expect(or1).to be_a Nodes::Grouping
+        expect(or1.combinator).to eq 'or'
+        expect(or2).to be_a Nodes::Grouping
+        expect(or2.combinator).to eq 'or'
       end
 
       it 'accepts "attributes" hashes for conditions' do
@@ -125,9 +125,9 @@ module Ransack
             }
         )
         conditions = search.base.conditions
-        conditions.should have(2).items
-        conditions.map { |c| c.class }
-        .should eq [Nodes::Condition, Nodes::Condition]
+        expect(conditions.size).to eq(2)
+        expect(conditions.map { |c| c.class })
+        .to eq [Nodes::Condition, Nodes::Condition]
       end
 
       it 'creates conditions for custom predicates that take arrays' do
@@ -137,15 +137,15 @@ module Ransack
 
         search = Search.new(Person, :name_ary_pred => ['Ernie', 'Bert'])
         condition = search.base[:name_ary_pred]
-        condition.should be_a Nodes::Condition
-        condition.predicate.name.should eq 'ary_pred'
-        condition.attributes.first.name.should eq 'name'
-        condition.value.should eq ['Ernie', 'Bert']
+        expect(condition).to be_a Nodes::Condition
+        expect(condition.predicate.name).to eq 'ary_pred'
+        expect(condition.attributes.first.name).to eq 'name'
+        expect(condition.value).to eq ['Ernie', 'Bert']
       end
 
       it 'does not evaluate the query on #inspect' do
         search = Search.new(Person, :children_id_in => [1, 2, 3])
-        search.inspect.should_not match /ActiveRecord/
+        expect(search.inspect).not_to match /ActiveRecord/
       end
     end
 
@@ -158,24 +158,24 @@ module Ransack
       }
       it 'evaluates conditions contextually' do
         search = Search.new(Person, :children_name_eq => 'Ernie')
-        search.result.should be_an ActiveRecord::Relation
+        expect(search.result).to be_an ActiveRecord::Relation
         where = search.result.where_values.first
-        where.to_sql.should match /#{children_people_name_field} = 'Ernie'/
+        expect(where.to_sql).to match /#{children_people_name_field} = 'Ernie'/
       end
 
       it 'evaluates compound conditions contextually' do
         search = Search.new(Person, :children_name_or_name_eq => 'Ernie')
-        search.result.should be_an ActiveRecord::Relation
+        expect(search.result).to be_an ActiveRecord::Relation
         where = search.result.where_values.first
-        where.to_sql.should match /#{children_people_name_field
+        expect(where.to_sql).to match /#{children_people_name_field
           } = 'Ernie' OR #{people_name_field} = 'Ernie'/
       end
 
       it 'evaluates polymorphic belongs_to association conditions contextually' do
         search = Search.new(Note, :notable_of_Person_type_name_eq => 'Ernie')
-        search.result.should be_an ActiveRecord::Relation
+        expect(search.result).to be_an ActiveRecord::Relation
         where = search.result.where_values.first
-        where.to_sql.should match /#{people_name_field} = 'Ernie'/
+        expect(where.to_sql).to match /#{people_name_field} = 'Ernie'/
       end
 
       it 'evaluates nested conditions' do
@@ -187,11 +187,11 @@ module Ransack
             }
           ]
         )
-        search.result.should be_an ActiveRecord::Relation
+        expect(search.result).to be_an ActiveRecord::Relation
         where = search.result.where_values.first
-        where.to_sql.should match /#{children_people_name_field} = 'Ernie'/
-        where.to_sql.should match /#{people_name_field} = 'Ernie'/
-        where.to_sql.should match /#{quote_table_name("children_people_2")
+        expect(where.to_sql).to match /#{children_people_name_field} = 'Ernie'/
+        expect(where.to_sql).to match /#{people_name_field} = 'Ernie'/
+        expect(where.to_sql).to match /#{quote_table_name("children_people_2")
           }.#{quote_column_name("name")} = 'Ernie'/
       end
 
@@ -202,14 +202,14 @@ module Ransack
             { :m => 'or', :name_eq => 'Bert', :children_name_eq => 'Bert' }
           ]
         )
-        search.result.should be_an ActiveRecord::Relation
+        expect(search.result).to be_an ActiveRecord::Relation
         where = search.result.where_values.first
         sql = where.to_sql
         first, second = sql.split(/ AND /)
-        first.should match /#{people_name_field} = 'Ernie'/
-        first.should match /#{children_people_name_field} = 'Ernie'/
-        second.should match /#{people_name_field} = 'Bert'/
-        second.should match /#{children_people_name_field} = 'Bert'/
+        expect(first).to match /#{people_name_field} = 'Ernie'/
+        expect(first).to match /#{children_people_name_field} = 'Ernie'/
+        expect(second).to match /#{people_name_field} = 'Bert'/
+        expect(second).to match /#{children_people_name_field} = 'Bert'/
       end
 
       it 'returns distinct records when passed :distinct => true' do
@@ -226,12 +226,12 @@ module Ransack
         else
           all_or_load, uniq_or_distinct = :load, :distinct
         end
-        search.result.send(all_or_load).
-          should have(9000).items
-        search.result(:distinct => true).
-          should have(10).items
-        search.result.send(all_or_load).send(uniq_or_distinct).
-          should eq search.result(:distinct => true).send(all_or_load)
+        expect(search.result.send(all_or_load).size).
+          to eq(9000)
+        expect(search.result(:distinct => true).size).
+          to eq(10)
+        expect(search.result.send(all_or_load).send(uniq_or_distinct)).
+          to eq search.result(:distinct => true).send(all_or_load)
       end
     end
 
@@ -242,65 +242,65 @@ module Ransack
 
       it 'creates sorts based on a single attribute/direction' do
         @s.sorts = 'id desc'
-        @s.sorts.should have(1).item
+        expect(@s.sorts.size).to eq(1)
         sort = @s.sorts.first
-        sort.should be_a Nodes::Sort
-        sort.name.should eq 'id'
-        sort.dir.should eq 'desc'
+        expect(sort).to be_a Nodes::Sort
+        expect(sort.name).to eq 'id'
+        expect(sort.dir).to eq 'desc'
       end
 
       it 'creates sorts based on a single attribute and uppercase direction' do
         @s.sorts = 'id DESC'
-        @s.sorts.should have(1).item
+        expect(@s.sorts.size).to eq(1)
         sort = @s.sorts.first
-        sort.should be_a Nodes::Sort
-        sort.name.should eq 'id'
-        sort.dir.should eq 'desc'
+        expect(sort).to be_a Nodes::Sort
+        expect(sort.name).to eq 'id'
+        expect(sort.dir).to eq 'desc'
       end
 
       it 'creates sorts based on a single attribute and without direction' do
         @s.sorts = 'id'
-        @s.sorts.should have(1).item
+        expect(@s.sorts.size).to eq(1)
         sort = @s.sorts.first
-        sort.should be_a Nodes::Sort
-        sort.name.should eq 'id'
-        sort.dir.should eq 'asc'
+        expect(sort).to be_a Nodes::Sort
+        expect(sort.name).to eq 'id'
+        expect(sort.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes/directions in array format' do
         @s.sorts = ['id desc', { :name => 'name', :dir => 'asc' }]
-        @s.sorts.should have(2).items
+        expect(@s.sorts.size).to eq(2)
         sort1, sort2 = @s.sorts
-        sort1.should be_a Nodes::Sort
-        sort1.name.should eq 'id'
-        sort1.dir.should eq 'desc'
-        sort2.should be_a Nodes::Sort
-        sort2.name.should eq 'name'
-        sort2.dir.should eq 'asc'
+        expect(sort1).to be_a Nodes::Sort
+        expect(sort1.name).to eq 'id'
+        expect(sort1.dir).to eq 'desc'
+        expect(sort2).to be_a Nodes::Sort
+        expect(sort2.name).to eq 'name'
+        expect(sort2.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes and uppercase directions in array format' do
         @s.sorts = ['id DESC', { :name => 'name', :dir => 'ASC' }]
-        @s.sorts.should have(2).items
+        expect(@s.sorts.size).to eq(2)
         sort1, sort2 = @s.sorts
-        sort1.should be_a Nodes::Sort
-        sort1.name.should eq 'id'
-        sort1.dir.should eq 'desc'
-        sort2.should be_a Nodes::Sort
-        sort2.name.should eq 'name'
-        sort2.dir.should eq 'asc'
+        expect(sort1).to be_a Nodes::Sort
+        expect(sort1.name).to eq 'id'
+        expect(sort1.dir).to eq 'desc'
+        expect(sort2).to be_a Nodes::Sort
+        expect(sort2.name).to eq 'name'
+        expect(sort2.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes and different directions in array format' do
         @s.sorts = ['id DESC', { name: 'name', dir: nil }]
-        @s.sorts.should have(2).items
+        expect(@s.sorts.size).to eq(2)
         sort1, sort2 = @s.sorts
-        sort1.should be_a Nodes::Sort
-        sort1.name.should eq 'id'
-        sort1.dir.should eq 'desc'
-        sort2.should be_a Nodes::Sort
-        sort2.name.should eq 'name'
-        sort2.dir.should eq 'asc'
+        expect(sort1).to be_a Nodes::Sort
+        expect(sort1.name).to eq 'id'
+        expect(sort1.dir).to eq 'desc'
+        expect(sort2).to be_a Nodes::Sort
+        expect(sort2.name).to eq 'name'
+        expect(sort2.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes/directions in hash format' do
@@ -308,12 +308,12 @@ module Ransack
           '0' => { :name => 'id', :dir => 'desc' },
           '1' => { :name => 'name', :dir => 'asc' }
         }
-        @s.sorts.should have(2).items
-        @s.sorts.should be_all { |s| Nodes::Sort === s }
+        expect(@s.sorts.size).to eq(2)
+        expect(@s.sorts).to be_all { |s| Nodes::Sort === s }
         id_sort = @s.sorts.detect { |s| s.name == 'id' }
         name_sort = @s.sorts.detect { |s| s.name == 'name' }
-        id_sort.dir.should eq 'desc'
-        name_sort.dir.should eq 'asc'
+        expect(id_sort.dir).to eq 'desc'
+        expect(name_sort.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes and uppercase directions in hash format' do
@@ -321,12 +321,12 @@ module Ransack
             '0' => { :name => 'id', :dir => 'DESC' },
             '1' => { :name => 'name', :dir => 'ASC' }
         }
-        @s.sorts.should have(2).items
-        @s.sorts.should be_all { |s| Nodes::Sort === s }
+        expect(@s.sorts.size).to eq(2)
+        expect(@s.sorts).to be_all { |s| Nodes::Sort === s }
         id_sort = @s.sorts.detect { |s| s.name == 'id' }
         name_sort = @s.sorts.detect { |s| s.name == 'name' }
-        id_sort.dir.should eq 'desc'
-        name_sort.dir.should eq 'asc'
+        expect(id_sort.dir).to eq 'desc'
+        expect(name_sort.dir).to eq 'asc'
       end
 
       it 'creates sorts based on multiple attributes and different directions in hash format' do
@@ -334,17 +334,17 @@ module Ransack
             '0' => { :name => 'id', :dir => 'DESC' },
             '1' => { :name => 'name', :dir => nil }
         }
-        @s.sorts.should have(2).items
-        @s.sorts.should be_all { |s| Nodes::Sort === s }
+        expect(@s.sorts.size).to eq(2)
+        expect(@s.sorts).to be_all { |s| Nodes::Sort === s }
         id_sort = @s.sorts.detect { |s| s.name == 'id' }
         name_sort = @s.sorts.detect { |s| s.name == 'name' }
-        id_sort.dir.should eq 'desc'
-        name_sort.dir.should eq 'asc'
+        expect(id_sort.dir).to eq 'desc'
+        expect(name_sort.dir).to eq 'asc'
       end
 
       it 'overrides existing sort' do
         @s.sorts = 'id asc'
-        @s.result.first.id.should eq 1
+        expect(@s.result.first.id).to eq 1
       end
     end
 
@@ -359,14 +359,14 @@ module Ransack
 
       it 'sets condition attributes when sent valid attributes' do
         @s.name_eq = 'Ernie'
-        @s.name_eq.should eq 'Ernie'
+        expect(@s.name_eq).to eq 'Ernie'
       end
 
       it 'allows chaining to access nested conditions' do
         @s.groupings = [
           { :m => 'or', :name_eq => 'Ernie', :children_name_eq => 'Ernie' }
         ]
-        @s.groupings.first.children_name_eq.should eq 'Ernie'
+        expect(@s.groupings.first.children_name_eq).to eq 'Ernie'
       end
     end
   end

--- a/spec/ransack/translate_spec.rb
+++ b/spec/ransack/translate_spec.rb
@@ -7,7 +7,7 @@ module Ransack
       it 'translate namespaced attribute like AR does' do
         ar_translation = ::Namespace::Article.human_attribute_name(:title)
         ransack_translation = Ransack::Translate.attribute(:title, :context => ::Namespace::Article.search.context)
-        ransack_translation.should eq ar_translation
+        expect(ransack_translation).to eq ar_translation
       end
     end
   end


### PR DESCRIPTION
Updated RSpec gemspec version from 2.8.0 to 2.14.0
Updated RSpec syntax from old `should` syntax to newer `expect` syntax
