### PR TITLE
Search.new and the ransack scope no longer modify the params hash

### DIFF
--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -12,8 +12,7 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
-          Search.new(self, params ? params.delete_if {
-            |k, v| v.blank? && v != false } : params, options)
+          Search.new(self, params, options)
         end
 
         def ransacker(name, opts = {}, &block)

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -14,8 +14,12 @@ module Ransack
              :translate, :to => :base
 
     def initialize(object, params = {}, options = {})
-      params = {} unless params.is_a?(Hash)
-      (params ||= {}).delete_if { |k, v| [*v].all?{|i| i.blank? && i != false } }
+      if params.is_a? Hash
+        params = params.dup
+        params.delete_if { |k, v| [*v].all?{|i| i.blank? && i != false } }
+      else
+        params = {}
+      end
       @context = Context.for(object, options)
       @context.auth_object = options[:auth_object]
       @base = Nodes::Grouping.new(@context, 'and')

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -17,6 +17,15 @@ module Ransack
           it 'has a Relation as its object' do
             subject.object.should be_an ::ActiveRecord::Relation
           end
+
+          it 'does not raise exception for string :params argument' do
+            lambda { Person.search('') }.should_not raise_error
+          end
+
+          it 'does not modify the parameters' do
+            params = { :name_eq => '' }
+            expect { Person.search(params)}.not_to change { params }
+          end
         end
 
         describe '#ransacker' do

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -147,6 +147,12 @@ module Ransack
         search = Search.new(Person, :children_id_in => [1, 2, 3])
         search.inspect.should_not match /ActiveRecord/
       end
+
+      it 'does not modify the parameters' do
+        params = { :name_eq => '' }
+        expect { Search.new(Person, params)}.not_to change { params }
+      end
+
     end
 
     describe '#result' do


### PR DESCRIPTION
Fixes #366
