### PR TITLE
Wildcard escaping with other databases

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -89,11 +89,11 @@ module Ransack
     # replace % \ to \% \\
     def escape_wildcards(unescaped)
       case ActiveRecord::Base.connection.adapter_name
-      when "SQLite"
-        unescaped
-      else
+      when "Mysql2", "PostgreSQL"
         # Necessary for PostgreSQL and MySQL
         unescaped.to_s.gsub(/([\\|\%|.])/, '\\\\\\1')
+      else
+        unescaped
       end
     end
   end


### PR DESCRIPTION
In using ransack with SQL Server, any search params passed to ransack containing a period are being escaped.  I don't believe that this behavior is required for SQL Server.

Escaping wildcards for certain databases should be opt-in, so the default for other databases would return the unescaped value.
