### PR TITLE
Migrated to polyamorous 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake'
 
 rails = ENV['RAILS'] || '4-1-stable'
 
-gem 'polyamorous', '~> 1.0.0'
+gem 'polyamorous', '~> 1.1.0'
 
 case rails
 when /\// # A path

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 4.0'
   s.add_dependency 'activesupport', '>= 4.0'
   s.add_dependency 'i18n'
-  s.add_dependency 'polyamorous', '~> 1.0.0'
+  s.add_dependency 'polyamorous', '~> 1.1.0'
   s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'


### PR DESCRIPTION
Specs are passing.

On rails 4.1 I need squeel which interferes with activeadmin.
Activeadmin uses ransack. Ransack uses 1.0.0 of polyamorous. Squeel needs 1.1.0... :)

so please merge it :)
