### PR TITLE
Make true and false predicates accept false values

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -38,18 +38,19 @@ module Ransack
         }
       ],
       ['true', {
-        :arel_predicate => 'eq',
+        :arel_predicate => proc { |v| v ? 'eq' : 'not_eq' },
         :compounds => false,
         :type => :boolean,
-        :validator => proc { |v| TRUE_VALUES.include?(v) }
+        :validator => proc { |v| BOOLEAN_VALUES.include?(v) },
+        :formatter => proc { |v| true }
         }
       ],
       ['false', {
-        :arel_predicate => 'eq',
+        :arel_predicate => proc { |v| v ? 'eq' : 'not_eq' },
         :compounds => false,
         :type => :boolean,
-        :validator => proc { |v| TRUE_VALUES.include?(v) },
-        :formatter => proc { |v| !v }
+        :validator => proc { |v| BOOLEAN_VALUES.include?(v) },
+        :formatter => proc { |v| false }
         }
       ],
       ['present', {

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -80,6 +80,38 @@ module Ransack
       end
     end
 
+    describe 'true' do
+      it 'generates an equality condition for boolean true' do
+        @s.awesome_true = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} = #{
+          ActiveRecord::Base.connection.quoted_true}/
+      end
+
+      it 'generates an inequality condition for boolean true' do
+        @s.awesome_true = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} != #{
+          ActiveRecord::Base.connection.quoted_true}/
+      end
+    end
+
+    describe 'false' do
+      it 'generates an equality condition for boolean false' do
+        @s.awesome_false = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} = #{
+          ActiveRecord::Base.connection.quoted_false}/
+      end
+
+      it 'generates an inequality condition for boolean false' do
+        @s.awesome_false = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("awesome")}"
+        expect(@s.result.to_sql).to match /#{field} != #{
+          ActiveRecord::Base.connection.quoted_false}/
+      end
+    end
+
     describe 'null' do
       it 'generates a value IS NULL query' do
         @s.name_null = true


### PR DESCRIPTION
This will make all boolean predicates more consistent, complementing #370.
