### PR TITLE
Avoid order indication in separate line in sort_link.

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -90,7 +90,7 @@ module Ransack
         link_to(
           [ERB::Util.h(name), order_indicator_for(current_dir)]
             .compact
-            .join(' ')
+            .join('&nbsp;')
             .html_safe,
           url,
           html_options

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -46,7 +46,7 @@ module Ransack
           should match /sort_link desc/
         }
         it {
-          should match /Full Name &#9660;/
+          should match /Full Name&nbsp;&#9660;/
         }
       end
 


### PR DESCRIPTION
It would be better to use `&nbsp;` instead of simple space in `sort_link` before the order indicator to avoid the order indication to be alone in a separate line.
Using css `white-space: nowrap;`on `.sort_link` is not good, if I want to allow to break a multi word `sort_link`.
