### PR TITLE
Context does not reference search

### DIFF
--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -2,7 +2,7 @@ require 'ransack/visitor'
 
 module Ransack
   class Context
-    attr_reader :search, :object, :klass, :base, :engine, :arel_visitor
+    attr_reader :object, :klass, :base, :engine, :arel_visitor
     attr_accessor :auth_object, :search_key
 
     class << self


### PR DESCRIPTION
Removes a confusing attr_reader which is not used anywhere.
