### PR TITLE
Support merging searches using shared context

### DIFF
--- a/lib/ransack/adapters/active_record/3.0/context.rb
+++ b/lib/ransack/adapters/active_record/3.0/context.rb
@@ -68,6 +68,22 @@ module Ransack
           .type
         end
 
+        # All dependent JoinAssociation items used in the search query
+        #
+        def join_associations
+          @join_dependency.join_associations
+        end
+
+        def join_sources
+          raise NotImplementedError,
+          "ActiveRecord 3.0 does not use join_sources or support joining relations with Arel::Join nodes. Use join_associations."
+        end
+
+        def alias_tracker
+          raise NotImplementedError,
+          "ActiveRecord 3.0 does not have an alias tracker"
+        end
+
         private
 
         def get_parent_and_attribute_name(str, parent = @base)

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -73,6 +73,30 @@ module Ransack
           @engine.connection_pool.columns_hash[table][name].type
         end
 
+        def join_associations
+          @join_dependency.join_associations
+        end
+
+        # All dependent Arel::Join nodes used in the search query
+        #
+        # This could otherwise be done as `@object.arel.join_sources`, except
+        # that ActiveRecord's build_joins sets up its own JoinDependency.
+        # This extracts what we need to access the joins using our existing
+        # JoinDependency to track table aliases.
+        #
+        def join_sources
+          base = Arel::SelectManager.new(@object.engine, @object.table)
+          joins = @object.joins_values
+          joins.each do |assoc|
+            assoc.join_to(base)
+          end
+          base.join_sources
+        end
+
+        def alias_tracker
+          @join_dependency.alias_tracker
+        end
+
         private
 
         def get_parent_and_attribute_name(str, parent = @base)

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -17,7 +17,7 @@ module Ransack
       params = {} unless params.is_a?(Hash)
       (params ||= {})
       .delete_if { |k, v| [*v].all? { |i| i.blank? && i != false } }
-      @context = Context.for(object, options)
+      @context = options[:context] || Context.for(object, options)
       @context.auth_object = options[:auth_object]
       @base = Nodes::Grouping.new(@context, options[:grouping] || 'and')
       @scope_args = {}

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -40,6 +40,13 @@ module Ransack
       it 'does not raise exception for string :params argument' do
         expect { Search.new(Person, '') }.not_to raise_error
       end
+
+      it 'accepts a context option' do
+        shared_context = Context.for(Person)
+        search1 = Search.new(Person, {"name_eq" => "A"}, context: shared_context)
+        search2 = Search.new(Person, {"name_eq" => "B"}, context: shared_context)
+        expect(search1.context).to be search2.context
+      end
     end
 
     describe '#build' do


### PR DESCRIPTION
When merging search criteria, it's necessary to use the same join dependency with a shared alias tracker. This can be achieved by passing a context option when building a Search object.

I've added the option and exposed `Context#alias_tracker`.
