### PR TITLE
Apply default scope conditions for association joins

### DIFF
--- a/lib/ransack/adapters/active_record/3.0/context.rb
+++ b/lib/ransack/adapters/active_record/3.0/context.rb
@@ -174,11 +174,21 @@ module Ransack
               :build, Polyamorous::Join.new(name, @join_type, klass), parent
               )
             found_association = @join_dependency.join_associations.last
+            apply_default_conditions(found_association)
             # Leverage the stashed association functionality in AR
             @object = @object.joins(found_association)
           end
 
           found_association
+        end
+
+        def apply_default_conditions(join_association)
+          reflection = join_association.reflection
+          default_scope = join_association.active_record.scoped
+          default_conditions = default_scope.arel.where_clauses
+          if default_conditions.any?
+            reflection.options[:conditions] = default_conditions
+          end
         end
 
       end

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -189,11 +189,21 @@ module Ransack
               :build, Polyamorous::Join.new(name, @join_type, klass), parent
               )
             found_association = @join_dependency.join_associations.last
+            apply_default_conditions(found_association)
             # Leverage the stashed association functionality in AR
             @object = @object.joins(found_association)
           end
 
           found_association
+        end
+
+        def apply_default_conditions(join_association)
+          reflection = join_association.reflection
+          default_scope = join_association.active_record.scoped
+          default_conditions = default_scope.arel.where_clauses
+          if default_conditions.any?
+            reflection.options[:conditions] = default_conditions
+          end
         end
 
       end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -89,6 +89,11 @@ module Ransack
         expect(condition.value).to eq 'Ernie'
       end
 
+      it 'preserves default scope conditions for associations' do
+        search = Search.new(Person, :articles_title_eq => 'Test')
+        expect(search.result.to_sql).to include "default_scope"
+      end
+
       it 'discards empty conditions' do
         search = Search.new(Person, :children_name_eq => '')
         condition = search.base[:children_name_eq]

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -88,6 +88,12 @@ class Article < ActiveRecord::Base
   has_many :comments
   has_and_belongs_to_many :tags
   has_many :notes, :as => :notable
+
+  if ActiveRecord::VERSION::STRING >= '3.1'
+    default_scope { where("'default_scope' = 'default_scope'") }
+  else # Rails 3.0 does not accept a block
+    default_scope where("'default_scope' = 'default_scope'")
+  end
 end
 
 module Namespace


### PR DESCRIPTION
Avoid selecting records from joins that would normally be filtered out if they were selected from the base table. Only applies to Rails 3, as this issue was fixed since Rails 4.
