### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ end
 ...
 <%= content_tag :table %>
   <%= content_tag :th, sort_link(@q, :last_name) %>
-  <%= content_tag :th, sort_link(@q, 'departments.title') %>
-  <%= content_tag :th, sort_link(@q, 'employees.last_name') %>
+  <%= content_tag :th, sort_link(@q, :departments_title) %>
+  <%= content_tag :th, sort_link(@q, :employees_last_name) %>
 <% end %>
 ```
 


### PR DESCRIPTION
The documentation for sort_link is outdated. Separating associations' fields' with `.` does not work. Using `_` does, at least in ransack 1.3.0.
