### PR TITLE
fix attribute translation for activerecord using STI having with both singular(one) and plural(other) translation keys

### DIFF
--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -135,8 +135,9 @@ module Ransack
     end
 
     def self.translated_attribute(associated_class)
-      "#{associated_class.i18n_scope}.attributes.#{
-        i18n_key(associated_class)}.#{@attr_name}".to_sym
+      key = "#{associated_class.i18n_scope}.attributes.#{
+        i18n_key(associated_class)}.#{@attr_name}"
+      ["#{key}.one".to_sym, key.to_sym]
     end
 
     def self.translated_ancestor_attributes


### PR DESCRIPTION
fix translated_ancestor_attributes for Active Record attributes translated like this

activerecord:
  attributes:
    family:
      child:
        one: child
        other: children

by preceding the key `family.child` with `family.child.one` in the returned array. 
If `family.child.one` is missing (meaning that no separate translation for singular/plural exists) it will be ignored and `family.child` will be used.
