### PR TITLE
Fix link label generation in sort_link when an options has is not passed

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -57,8 +57,7 @@ module Ransack
           Array(field_name)
         end
 
-        label_text =
-        if !args.first.try(:is_a?, Hash)
+        label_text = if String === args.first
           args.shift.to_s
         else
           Translate.attribute(field_name, :context => search.context)


### PR DESCRIPTION
This fixes the bug introduced by #438 talked about in that thread.

Not passing an options hash into sort_link caused it to fail to look up the link title.

This is because `!args.first.try(:is_a?, Hash)` would return true if the length of args was 0.

I've simplified the logic to just test if the next parameter in args is a String (rather than test if it's not a Hash).

I haven't created a test for this, since the tests all pass in an options hash (to pass in the `controller` parameter), but I wanted to make sure this works for you.

I tested it on a project I'm working on, and this patch fixed the problem that you were experiencing.
