### PR TITLE
Check exact matches before splitting

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -127,6 +127,7 @@ module Ransack
 
       def attribute_method?(name)
         name = strip_predicate_and_index(name)
+        return true if @context.attribute_method?(name)
         case name
         when /^(g|c|m|groupings|conditions|combinator)=?$/
           true

--- a/spec/ransack/nodes/grouping_spec.rb
+++ b/spec/ransack/nodes/grouping_spec.rb
@@ -7,7 +7,29 @@ module Ransack
         @g = 1
       end
 
+      let(:context) { Context.for(Person) }
 
+      subject { described_class.new(context) }
+
+      describe '#attribute_method?' do
+        context 'for attributes of the context' do
+          it 'is true' do
+            expect(subject.attribute_method?('name')).to be_true
+          end
+
+          context "where the attribute contains '_and_'" do
+            it 'is true' do
+              expect(subject.attribute_method?('terms_and_conditions')).to be_true
+            end
+          end
+        end
+
+        context 'for unknown attributes' do
+          it 'is false' do
+            expect(subject.attribute_method?('not_an_attribute')).to be_false
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -135,6 +135,7 @@ module Schema
         t.string   :only_admin
         t.integer  :salary
         t.boolean  :awesome, default: false
+        t.boolean  :terms_and_conditions, default: false
         t.timestamps null: false
       end
 


### PR DESCRIPTION
- if the supplied name contains '_and_' or '_or_' we should check
  if it exists before splitting and checking the parts, this way we
  handle 'terms_and_conditions' as well as pairs of fields like
  'name_and_email'.
