### PR TITLE
README Sort by associations fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ end
 ...
 <%= content_tag :table %>
   <%= content_tag :th, sort_link(@q, :last_name) %>
-  <%= content_tag :th, sort_link(@q, 'departments.title') %>
-  <%= content_tag :th, sort_link(@q, 'employees.last_name') %>
+  <%= content_tag :th, sort_link(@q, 'departments_title') %>
+  <%= content_tag :th, sort_link(@q, 'employees_last_name') %>
 <% end %>
 ```
 


### PR DESCRIPTION
To sort by an association you need to use `#{model_name}_#{attribute_name}` instead of `#{model_name}.#{attribute_name}`. At least for Rails 4.1.

You also need to join that association. Should I add that too?
