### PR TITLE
Make search_form_for's default :as option respect custom search_key

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -28,7 +28,7 @@ module Ransack
             "#{search.klass.to_s.underscore}_search",
           :method => :get
         }
-        options[:as] ||= Ransack::Constants::DEFAULT_SEARCH_KEY
+        options[:as] ||= Ransack.options[:search_key]
         options[:html].reverse_merge!(html_options)
         options[:builder] ||= FormBuilder
 

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -301,6 +301,17 @@ module Ransack
         it { should match /action="\/people.json"/ }
       end
 
+      describe '#search_form_for with custom default search key' do
+        before do
+          Ransack.configure { |c| c.search_key = :example }
+        end
+        subject {
+          @controller.view_context
+          .search_form_for(Person.search) { |f| f.text_field :name_eq }
+        }
+        it { should match /example_name_eq/ }
+      end
+
     end
   end
 end


### PR DESCRIPTION
Prior to this change, if you set a custom `search_key` option in the initializer, you'd have to also pass an `as: :whatever` option to all of your search forms.

Fixes #92 
