### PR TITLE
Add ability to remove sort_link arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ This example toggles the sort directions of both fields, by default
 initially sorting the `last_name` field by ascending order, and the
 `first_name` field by descending order.
 
+You can remove the order indicator arrow by passing hide_indicator: true
+
+```erb
+<%= sort_link(@q, :name, hide_indicator: true) %>
+```
+
 ### Advanced Mode
 
 "Advanced" searches (ab)use Rails' nested attributes functionality in order to

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -65,6 +65,7 @@ module Ransack
           end
 
         options = args.first.is_a?(Hash) ? args.shift.dup : {}
+        hide_indicator = options.delete :hide_indicator
         default_order = options.delete :default_order
         default_order_is_a_hash = Hash === default_order
 
@@ -133,27 +134,27 @@ module Ransack
           url_for(options_for_url)
         end
 
-        name = link_name(label_text, field_current_dir)
+        name = link_name(label_text, field_current_dir, hide_indicator)
 
         link_to(name, url, html_options)
       end
 
       private
 
-      def link_name(label_text, dir)
-        [ERB::Util.h(label_text), order_indicator_for(dir)]
+      def link_name(label_text, dir, hide_indicator)
+        [ERB::Util.h(label_text), order_indicator_for(dir, hide_indicator)]
         .compact
         .join(Constants::NON_BREAKING_SPACE)
         .html_safe
       end
 
-      def order_indicator_for(dir)
-        if dir == Constants::ASC
+      def order_indicator_for(dir, hide_indicator)
+        if hide_indicator
+          nil
+        elsif dir == Constants::ASC
           Constants::ASC_ARROW
         elsif dir == Constants::DESC
           Constants::DESC_ARROW
-        else
-          nil
         end
       end
 

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -280,6 +280,18 @@ module Ransack
         end
       end
 
+      describe '#sort_link without order indicator' do
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(:sorts => ['name desc'])],
+            :name,
+            :controller => 'people',
+            :hide_indicator => true
+          )
+        }
+        it { should match /Full Name<\/a>/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context.search_form_for(Person.search) {} }
         it { should match /action="\/people"/ }


### PR DESCRIPTION
This change adds the ability to remove the order indicating arrows in `sort_link`.

Usage:

``` erb
<%= sort_link(@q, :name, hide_indicator: true) %>
```

Fixes #430 
