### PR TITLE
change usage of uniq in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ this example, with preloading each Person's Articles and pagination):
 def index
   @q = Person.search(params[:q])
   @people = @q.result.includes(:articles).page(params[:page])
-  # or use `to_a.uniq` to remove duplicates (can also be done in the view):
-  @people = @q.result.includes(:articles).page(params[:page]).to_a.uniq
+  # or use `uniq` to remove duplicates:
+  @people = @q.result.includes(:articles).uniq.page(params[:page])
 end
 ```
 


### PR DESCRIPTION
``` diff
-  # or use `to_a.uniq` to remove duplicates (can also be done in the view):
-  @people = @q.result.includes(:articles).page(params[:page]).to_a.uniq
+  # or use `uniq` to remove duplicates:
+  @people = @q.result.includes(:articles).uniq.page(params[:page])
```

It doesn't make sense to call `uniq` on the array. If there are a page size of 10 with doubled results  and I remove them from the array the page has less then 10 items. If I call `uniq` on the relation the db handles this and I get the full page size of 10 items. And I can work with the relation in the frontend and I'm not limited to the array.
