### PR TITLE
[472] Allow arrays to be received for custom ransacker

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -18,6 +18,7 @@ module Ransack
             predicates.inject(&:or)
           end
         else
+          predicates.first.right[0] = predicates.first.right[0].val if predicates.first.right[0].class == Arel::Nodes::Casted
           predicates.first
         end
       end

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -18,7 +18,7 @@ module Ransack
             predicates.inject(&:or)
           end
         else
-          predicates.first.right[0] = predicates.first.right[0].val if predicates.first.right[0].class == Arel::Nodes::Casted
+          predicates.first.right[0] = predicates.first.right[0].val if defined?(Arel::Nodes::Casted) && predicates.first.class == Arel::Nodes::In && predicates.first.right.is_a?(Array) && predicates.first.right[0].class == Arel::Nodes::Casted
           predicates.first
         end
       end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -161,6 +161,11 @@ module Ransack
             expect(s.result.to_a).to eq [p]
           end
 
+          it "should function correctly when an array is passed into custom ransacker with _in" do
+            s = Person.search(array_users_in: true)
+            expect(s.result.length).to be > 0
+          end
+
           it "should function correctly when an attribute name ends with '_start'" do
             p = Person.create!(:new_start => 'Bar and foo', :name => 'Xiang')
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -45,6 +45,10 @@ class Person < ActiveRecord::Base
     parent.table[:name]
   end
 
+  ransacker :array_users, formatter: proc { |v| Person.first(2).map(&:id) } do |parent|
+    parent.table[:id]
+  end
+
   ransacker :doubled_name do |parent|
     Arel::Nodes::InfixOperation.new(
       '||', parent.table[:name], parent.table[:name]


### PR DESCRIPTION
This is a try at fixing #472 and it works for me. Arel's update now has an Arel::Nodes::Casted type instead of the original array, so NULL gets passed into the SQL statement. This should cover all cases, and an if statement has been placed so this only will apply for when the Arel::Nodes::Casted type is used.