### PR TITLE
Allow string arrays to be received for custom ransacker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ henceforth should be documented here.
 
 ### Fixed
 
-*   Fix passing in arrays for custom ransackers searching by id, to improve
-    compatibility with Rails 4.2 (Arel 6.0).
+*   Fix passing in arrays for custom ransackers, to improve compatibility 
+    with Rails 4.2 (Arel 6.0).
     ([pull request](https://github.com/activerecord-hackery/ransack/pull/486))
+    ([pull request](https://github.com/activerecord-hackery/ransack/pull/488))
 
     *Idean Labib*
 

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -31,6 +31,7 @@ module Ransack
         def return_predicate(predicate)
           if casted_array_with_in_predicate?(predicate)
             predicate.right[0] = predicate.right[0].val
+            predicate.right[0].map! { |v| v.is_a?(String) ? Arel::Nodes.build_quoted(v) : v }
           end
           predicate
         end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -161,9 +161,17 @@ module Ransack
             expect(s.result.to_a).to eq [p]
           end
 
-          it "should function correctly when an array is passed into custom ransacker with _in" do
-            s = Person.search(array_users_in: true)
-            expect(s.result.length).to be > 0
+          context "when an array is passed into a custom ransacker with _in" do
+            it "should function correctly with ids." do
+              s = Person.search(array_users_in: true)
+              expect(s.result.length).to be > 0
+            end
+
+            it "should function correctly with strings." do
+              p = Person.create!(name: Person.first.id.to_s)
+              s = Person.search(array_names_in: true)
+              expect(s.result.length).to be > 0
+            end
           end
 
           it "should function correctly when an attribute name ends with '_start'" do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -49,6 +49,10 @@ class Person < ActiveRecord::Base
     parent.table[:id]
   end
 
+  ransacker :array_names, formatter: proc { |v| Person.first(2).map {|p| p.id.to_s } } do |parent|
+    parent.table[:name]
+  end
+
   ransacker :doubled_name do |parent|
     Arel::Nodes::InfixOperation.new(
       '||', parent.table[:name], parent.table[:name]


### PR DESCRIPTION
This is a fix for the last example in #472 in which filtering on a string field does not work in Arel >= 6. The test written passes with Arel 5 without the fix, and the fix allows the test to pass in Arel 6.