### PR TITLE
Don't replace 0 and 1 with false and true, fixes #502

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+*   When sanitizing scope arguments, do not replace 0 and 1 with false and true
+    cf. https://github.com/activerecord-hackery/ransack/issues/502
+
+    *Gabe Kopley*
+
+
 ## Version 1.6.3 - 2015-01-21
 
 *   Fix a regression

--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -40,8 +40,8 @@ module Ransack
     STASHED_JOIN        = 'stashed_join'.freeze
     JOIN_NODE           = 'join_node'.freeze
 
-    TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE'].to_set
-    FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE'].to_set
+    TRUE_VALUES = [true, 't', 'T', 'true', 'TRUE'].to_set
+    FALSE_VALUES = [false, 'f', 'F', 'false', 'FALSE'].to_set
     BOOLEAN_VALUES = (TRUE_VALUES + FALSE_VALUES).freeze
 
     S_SORTS             = %w(s sorts).freeze

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -20,7 +20,8 @@ module Ransack
 
           context 'with scopes' do
             before do
-              Person.stub :ransackable_scopes => [:active, :over_age, :of_age]
+              Person.stub :ransackable_scopes =>
+                [:active, :over_age, :of_age, :article_count_equals]
             end
 
             it "applies true scopes" do
@@ -67,6 +68,23 @@ module Ransack
               search = Person.ransack('over_age' => 18, 'active' => true)
               search.result.to_sql.should include "age > 18"
               search.result.to_sql.should include "active = 1"
+            end
+
+            context "applying joins/group/having scope" do
+              it "applies scope correctly when input is 0" do
+                search = Person.ransack('article_count_equals' => 0)
+                search.result.to_sql.should include "HAVING count(articles.id) = 0"
+              end
+
+              it "applies scope correctly when input is 1" do
+                search = Person.ransack('article_count_equals' => 1)
+                search.result.to_sql.should include "HAVING count(articles.id) = 1"
+              end
+
+              it "applies scope correctly when input is 1337" do
+                search = Person.ransack('article_count_equals' => 1337)
+                search.result.to_sql.should include "HAVING count(articles.id) = 1337"
+              end
             end
           end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -42,6 +42,9 @@ class Person < ActiveRecord::Base
   scope :of_age,      lambda { |of_age|
     of_age ? where("age >= ?", 18) : where("age < ?", 18)
   }
+  scope :article_count_equals, lambda { |n|
+    joins(:articles).group("people.id").having("count(articles.id) = ?", n)
+  }
 
   ransacker :reversed_name, :formatter => proc { |v| v.reverse } do |parent|
     parent.table[:name]


### PR DESCRIPTION
The TRUE_VALUES and FALSE_VALUES haven't been changed since the initial commit 294015309b03240c6a9a9aea69118a24d7f737ac , yet my removing the values that I have removed doesn't break any tests.

@ernie do you remember the purpose for the values I propose removing?