### PR TITLE
Fix NoMethodError in casted_array_with_in_predicate?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -43,6 +43,7 @@ module Ransack
         def casted_array_with_in_predicate?(predicate)
           return unless defined?(Arel::Nodes::Casted)
           predicate.class == Arel::Nodes::In &&
+          predicate.right[0].respond_to?(:val) &&
           predicate.right[0].val.is_a?(Array)
         end
 

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -18,6 +18,14 @@ module Ransack
             expect(subject.object).to be_an ::ActiveRecord::Relation
           end
 
+          context 'using ransacker with a SqlLiteral callable' do
+            it 'should not raise an error' do
+              # The `with_banana` ransacker has a SqlLiteral callable
+              search = Person.search("with_banana_in" => "peel")
+              expect { search.result }.to_not raise_error
+            end
+          end
+
           context 'with scopes' do
             before do
               Person.stub :ransackable_scopes =>

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -50,6 +50,17 @@ class Person < ActiveRecord::Base
     parent.table[:name]
   end
 
+  # The `with_banana` ransacker is just to reproduce a
+  # particular issue (#504) and probably should be removed
+  # eventually, because it doesn't represent a useful
+  # ransacker one might want in an actual application.
+  ransacker(:with_banana,
+    callable: proc { |parent|
+      Arel::Nodes::SqlLiteral.new("#{Article.table_name}.banana")
+    },
+    formatter: proc { |v| v }
+  )
+
   ransacker :array_users,
     formatter: proc { |v| Person.first(2).map(&:id) } do |parent|
     parent.table[:id]


### PR DESCRIPTION
This failing test reproduces https://github.com/activerecord-hackery/ransack/issues/504

It's a much-simplified version of a ransacker in my application which worked in 1.5.1 and 1.6.0, but which fails in subsequent releases, including master, because of https://github.com/activerecord-hackery/ransack/commit/6c59e96adaa43f4e8141352f508b84a046343591 as explained in https://github.com/activerecord-hackery/ransack/issues/504

Disclaimer: This is the first time I've ever worked with ransack or arel in detail, and I'm not the one who wrote the ransacker in my app.  I'm just trying to upgrade to the latest ransack (1.6.3).