### PR TITLE
Gitignore rubymine's .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea


### PR DESCRIPTION
If everyone on the project used Intellij / rubymine, we might want to commit the `.idea` directory some day, but, as this is OSS and it's unlikely that everyone will use the same IDE, we'll probably never want to commit `.idea`.  So, git-ignoring it is a matter of convenience for rubymine users.