### PR TITLE
Allow ransacker to have its arguments

### DIFF
--- a/lib/ransack/nodes/attribute.rb
+++ b/lib/ransack/nodes/attribute.rb
@@ -3,14 +3,15 @@ module Ransack
     class Attribute < Node
       include Bindable
 
-      attr_reader :name
+      attr_reader :name, :rargs
 
       delegate :blank?, :present?, :==, :to => :name
       delegate :engine, :to => :context
 
-      def initialize(context, name = nil)
+      def initialize(context, name = nil, rargs = [])
         super(context)
         self.name = name unless name.blank?
+        @rargs = rargs
       end
 
       def name=(name)

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -66,7 +66,7 @@ module Ransack
           end
         when Hash
           args.each do |index, attrs|
-            attr = Attribute.new(@context, attrs[:name])
+            attr = Attribute.new(@context, attrs[:name], attrs[:rargs])
             self.attributes << attr if attr.valid?
           end
         else

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -314,7 +314,7 @@ module Ransack
             )
           end
 
-          it 'searches by ransacker with ransacker_attributes', focus: true do
+          it 'searches by ransacker with ransacker_attributes' do
             s = Person.ransack(
               c: [{
                 a: {
@@ -324,7 +324,7 @@ module Ransack
                   }
                 },
                 p: 'cont',
-                v: ['Rails 5.0 released']
+                v: ['Rails has been released']
               }]
             )
 
@@ -333,7 +333,7 @@ module Ransack
             )
 
             expect(s.result.to_sql).to match(
-              /LIKE \'\%Rails 5\.0 released\%\'/
+              /LIKE \'\%Rails has been released\%\'/
             )
           end
         end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -313,6 +313,29 @@ module Ransack
                 quote_column_name("only_admin")} = 'htimS cirA'/
             )
           end
+
+          it 'searches by ransacker with ransacker_attributes', focus: true do
+            s = Person.ransack(
+              c: [{
+                a: {
+                  '0' => {
+                    name: 'articles_title_with_specified_body_size',
+                    rargs: [10, 100]
+                  }
+                },
+                p: 'cont',
+                v: ['Rails 5.0 released']
+              }]
+            )
+
+            expect(s.result.to_sql).to match(
+              /CHAR_LENGTH\(articles.body\) BETWEEN 10 AND 100/
+            )
+
+            expect(s.result.to_sql).to match(
+              /LIKE \'\%Rails 5\.0 released\%\'/
+            )
+          end
         end
 
         describe '#ransackable_attributes' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -67,6 +67,21 @@ class Person < ActiveRecord::Base
     Arel.sql('people.id')
   end
 
+  ransacker :articles_title_with_specified_body_size, args: [:parent, :rargs] do |parent, rargs|
+    min_body = rargs[0]
+    max_body = rargs[1]
+
+    sql = <<-SQL
+      (SELECT title
+         FROM articles
+        WHERE articles.person_id = people.id
+          AND CHAR_LENGTH(articles.body) BETWEEN #{min_body} AND #{max_body}
+      )
+    SQL
+
+    Arel.sql(sql.squish)
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     if auth_object == :admin
       column_names + _ransackers.keys - ['only_sort']


### PR DESCRIPTION
This is related to https://github.com/activerecord-hackery/ransack/issues/508 but I have another use case:

In my project I have Customer and Deal models. Customers have many Deals and each deal has `amount` attribute. I want to find customers which have made deals with total amount more than specified value for the last week. So my ransacker is:

```ruby
# app/models/customer.rb
ransacker :sum_of_deals_last_week do |parent|
  deals_table = Deal.arel_table

  Arel::Nodes::Grouping.new(
    deals_table
      .project(Arel::Nodes::Sum.new([deals_table[:amount]]))
      .group(deals_table[:customer_id])
      .where(deals_table[:customer_id].eq(parent.table[:id])
        .and(deals_table[:created_at].gteq(1.week.ago.to_date)
          .and(deals_table[:created_at].lteq(Date.today))
        )
      ).ast
  )
end
```

And I can easily filter:

```ruby
Customer.ransack(sum_of_deals_last_week_gt: 100)
```

The problem occurs when I want to change period of time. Say, for last month period I need to create new ransacker. What if I need to dynamically specify this period?

So with changes in this PR the following ransacker can be created:

```ruby
# app/models/customer.rb
ransacker :sum_of_deals, args: [:parent, :rargs] do |parent, rargs|
  date_from = rargs[0]
  date_till = rargs[1]
  deals_table = Deal.arel_table

  Arel::Nodes::Grouping.new(
    deals_table
      .project(Arel::Nodes::Sum.new([deals_table[:amount]]))
      .group(deals_table[:customer_id])
      .where(deals_table[:customer_id].eq(parent.table[:id])
        .and(deals_table[:created_at].gteq(date_from)
          .and(deals_table[:created_at].lteq(date_till))
        )
      ).ast
  )
end
```

And I can use this ransacker:

```ruby
Customer.ransack(
  c: [{
    a: { '0' => { name: :sum_of_deals, rargs: [1.week.ago.to_date, Date.today] } },
    p: :gt,
    v: [100]
  }]
)
```
