### PR TITLE
Allow to use model name from I18n ransack scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ en:
       end: ends with
       gt: greater than
       lt: less than
+    models:
+      person: Passanger
     attributes:
       person:
         name: Full Name

--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -59,7 +59,8 @@ module Ransack
 
       defaults =
         if key.blank?
-          [:"#{context.klass.i18n_scope}.models.#{i18n_key(context.klass)}"]
+          [:"ransack.models.#{i18n_key(context.klass)}",
+           :"#{context.klass.i18n_scope}.models.#{i18n_key(context.klass)}"]
         else
           [:"ransack.associations.#{i18n_key(context.klass)}.#{key}"]
         end


### PR DESCRIPTION
This simple pull request allow us to use I18n model names from ransack scope, not only from activerecord scope, similarly as for attribute names.
Background:
1. I need in attribute select different name for the base model as generally.
2. So is the using of I18n in ransack unified.