### PR TITLE
Ransacker arguments sort

### DIFF
--- a/lib/ransack/nodes/sort.rb
+++ b/lib/ransack/nodes/sort.rb
@@ -3,7 +3,7 @@ module Ransack
     class Sort < Node
       include Bindable
 
-      attr_reader :name, :dir
+      attr_reader :name, :dir, :ransacker_args
       i18n_word :asc, :desc
 
       class << self
@@ -16,7 +16,7 @@ module Ransack
 
       def build(params)
         params.with_indifferent_access.each do |key, value|
-          if key.match(/^(name|dir)$/)
+          if key.match(/^(name|dir|ransacker_args)$/)
             self.send("#{key}=", value)
           end
         end
@@ -43,6 +43,10 @@ module Ransack
           else
             Constants::ASC
           end
+      end
+
+      def ransacker_args=(ransack_args)
+        @ransacker_args = ransack_args
       end
 
     end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -339,26 +339,29 @@ module Ransack
               c: [{
                 a: {
                   '0' => {
-                    name: 'dynamic_hstore',
-                    ransacker_args: ['hstore_column', 'example_field']
+                    name: 'with_passed_arguments',
+                    ransacker_args: [10, 100]
                   }
                 },
                 p: 'cont',
-                v: ['Some Value']
+                v: ['Rails has been released']
               }],
               s: {
                 '0' => {
-                  'name' => 'dynamic_hstore',
-                  'dir' => 'asc',
-                  'ransacker_args' => ['hstore_column', 'example_field']
+                  name: 'with_passed_arguments',
+                  dir: 'asc',
+                  ransacker_args: [10, 100]
                 }
               }
             )
             expect(s.result.to_sql).to match(
-              /(\"people\".\"hstore_column\" -> 'example_field' LIKE '%Some Value%')/
+              /CHAR_LENGTH\(articles.body\) BETWEEN 10 AND 100/
             )
             expect(s.result.to_sql).to match(
-              /ORDER BY \"people\".\"hstore_column\" -> 'example_field' ASC/
+              /LIKE \'\%Rails has been released\%\'/
+            )
+            expect(s.result.to_sql).to match(
+              /ORDER BY \(SELECT.*CHAR_LENGTH\(articles.body\) BETWEEN 10 AND 100/
             )
           end
         end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -333,6 +333,34 @@ module Ransack
               /LIKE \'\%Rails has been released\%\'/
             )
           end
+
+          it 'should allow search and sort passing ransacker arguments to a ransacker' do
+            s = Person.ransack(
+              c: [{
+                a: {
+                  '0' => {
+                    name: 'dynamic_hstore',
+                    ransacker_args: ['hstore_column', 'example_field']
+                  }
+                },
+                p: 'cont',
+                v: ['Some Value']
+              }],
+              s: {
+                '0' => {
+                  'name' => 'dynamic_hstore',
+                  'dir' => 'asc',
+                  'ransacker_args' => ['hstore_column', 'example_field']
+                }
+              }
+            )
+            expect(s.result.to_sql).to match(
+              /(\"people\".\"hstore_column\" -> 'example_field' LIKE '%Some Value%')/
+            )
+            expect(s.result.to_sql).to match(
+              /ORDER BY \"people\".\"hstore_column\" -> 'example_field' ASC/
+            )
+          end
         end
 
         describe '#ransackable_attributes' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -80,11 +80,6 @@ class Person < ActiveRecord::Base
     Arel.sql(sql.squish)
   end
 
-  ransacker :dynamic_hstore, args: [:parent, :ransacker_args] do |parent, args|
-    column, field = args
-    Arel::Nodes::InfixOperation.new("->", Person.arel_table[column], Arel::Nodes.build_quoted(field))
-  end
-
   def self.ransackable_attributes(auth_object = nil)
     if auth_object == :admin
       column_names + _ransackers.keys - ['only_sort']

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -80,6 +80,11 @@ class Person < ActiveRecord::Base
     Arel.sql(sql.squish)
   end
 
+  ransacker :dynamic_hstore, args: [:parent, :ransacker_args] do |parent, args|
+    column, field = args
+    Arel::Nodes::InfixOperation.new("->", Person.arel_table[column], Arel::Nodes.build_quoted(field))
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     if auth_object == :admin
       column_names + _ransackers.keys - ['only_sort']


### PR DESCRIPTION
....

Hello guys, I found ransacker_args pretty cool, but I need to use same ransacker to sort fields.

Here some sample code for PostgreSQL hstore:

    # model/Person.rb
    ransacker :dynamic_hstore, args: [:parent, :ransacker_args] do |parent, args|
      column, field = args
      Arel::Nodes::InfixOperation.new("->", Person.arel_table[column], Arel::Nodes.build_quoted(field))
    end

    # Test
    s = Person.ransack(
      c: [{
        a: {
          '0' => {
            name: 'dynamic_hstore',
            ransacker_args: ['hstore_column', 'example_field']
          }
        },
        p: 'cont',
        v: ['Some Value']
      }],
      s: {
        '0' => {
          'name' => 'dynamic_hstore',
          'dir' => 'asc',
          'ransacker_args' => ['hstore_column', 'example_field']
        }
      }
    )

    s.result.to_sql
    => SELECT "people".* FROM "people" WHERE ("people"."hstore_column" -> 'example_field' ILIKE '%Some Value%')  ORDER BY "people"."hstore_column" -> 'example_field' ASC

Hope you like it, thanks.

Aldrin.