### PR TITLE
allowing ':wants_array' to be passed as 'false' in predicate options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+*   Allowing `:wants_array` to be set to `false` in the predicate options.
+    ([#32](https://github.com/activerecord-hackery/ransack/issues/32))
+
+    *Michael Pavling*
+
 ## Version 1.6.4 - 2015-03-20
 
 *   ActionView patch to maintain compatibility with Rails 4.2.1 released today.

--- a/lib/ransack/predicate.rb
+++ b/lib/ransack/predicate.rb
@@ -48,8 +48,8 @@ module Ransack
       @validator = opts[:validator] ||
         lambda { |v| v.respond_to?(:empty?) ? !v.empty? : !v.nil? }
       @compound = opts[:compound]
-      @wants_array = opts[:wants_array] == true || @compound ||
-        Constants::IN_NOT_IN.include?(@arel_predicate)
+      @wants_array = opts.fetch(:wants_array,
+        @compound || Constants::IN_NOT_IN.include?(@arel_predicate))
     end
 
     def eql?(other)

--- a/spec/mongoid/configuration_spec.rb
+++ b/spec/mongoid/configuration_spec.rb
@@ -62,5 +62,41 @@ module Ransack
       expect(Ransack.predicates).not_to have_key 'test_array_predicate_any'
       expect(Ransack.predicates).not_to have_key 'test_array_predicate_all'
     end
+
+    describe '`wants_array` option takes precedence over Arel predicate' do
+      it 'implicitly wants an array for in/not in predicates' do
+        Ransack.configure do |config|
+          config.add_predicate(
+            :test_in_predicate,
+            :arel_predicate => 'in'
+          )
+          config.add_predicate(
+            :test_not_in_predicate,
+            :arel_predicate => 'not_in'
+          )
+        end
+
+        expect(Ransack.predicates['test_in_predicate'].wants_array).to eq true
+        expect(Ransack.predicates['test_not_in_predicate'].wants_array).to eq true
+      end
+
+      it 'explicitly does not want array for in/not_in predicates' do
+        Ransack.configure do |config|
+          config.add_predicate(
+            :test_in_predicate_no_array,
+            :arel_predicate => 'in',
+            :wants_array => false
+          )
+          config.add_predicate(
+            :test_not_in_predicate_no_array,
+            :arel_predicate => 'not_in',
+            :wants_array => false
+          )
+        end
+
+        expect(Ransack.predicates['test_in_predicate_no_array'].wants_array).to eq false
+        expect(Ransack.predicates['test_not_in_predicate_no_array'].wants_array).to eq false
+      end
+    end
   end
 end

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -64,5 +64,41 @@ module Ransack
       expect(Ransack.predicates).not_to have_key 'test_array_predicate_any'
       expect(Ransack.predicates).not_to have_key 'test_array_predicate_all'
     end
+
+    describe '`wants_array` option takes precedence over Arel predicate' do
+      it 'implicitly wants an array for in/not in predicates' do
+        Ransack.configure do |config|
+          config.add_predicate(
+            :test_in_predicate,
+            :arel_predicate => 'in'
+          )
+          config.add_predicate(
+            :test_not_in_predicate,
+            :arel_predicate => 'not_in'
+          )
+        end
+
+        expect(Ransack.predicates['test_in_predicate'].wants_array).to eq true
+        expect(Ransack.predicates['test_not_in_predicate'].wants_array).to eq true
+      end
+
+      it 'explicitly does not want array for in/not_in predicates' do
+        Ransack.configure do |config|
+          config.add_predicate(
+            :test_in_predicate_no_array,
+            :arel_predicate => 'in',
+            :wants_array => false
+          )
+          config.add_predicate(
+            :test_not_in_predicate_no_array,
+            :arel_predicate => 'not_in',
+            :wants_array => false
+          )
+        end
+
+        expect(Ransack.predicates['test_in_predicate_no_array'].wants_array).to eq false
+        expect(Ransack.predicates['test_not_in_predicate_no_array'].wants_array).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
Addressing https://github.com/activerecord-hackery/ransack/issues/32