### PR TITLE
Fix erroneous reference to AR class

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -184,7 +184,7 @@ module Ransack
               :string_join
             when Hash, Symbol, Array
               :association_join
-            when ActiveRecord::Associations::JoinDependency
+            when ::ActiveRecord::Associations::JoinDependency
               :stashed_join
             when Arel::Nodes::Join
               :join_node

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -184,7 +184,7 @@ module Ransack
               :string_join
             when Hash, Symbol, Array
               :association_join
-            when ::ActiveRecord::Associations::JoinDependency
+            when Polyamorous::JoinDependency, Polyamorous::JoinAssociation
               :stashed_join
             when Arel::Nodes::Join
               :join_node


### PR DESCRIPTION
9e818cde introduced a bug by making an erroneous reference to `ActiveRecord::Associations::JoinDependency` in line 187. As this class lives inside an `ActiveRecord` module, that reference needs to be absolute in order to properly point at AR's class.