### PR TITLE
Create aliases for (long) search fields

### DIFF
--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -14,6 +14,14 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
+          params.keys.each do |k|
+            search_attr = k.to_s.sub(/_#{Ransack::Predicate.detect_from_string(k.to_s)}$/, Ransack::Constants::EMPTY)
+            search_pred = k.to_s.sub(/^#{search_attr}_/, Ransack::Constants::EMPTY)
+            if _ransacker_aliases.has_key?(search_attr)
+              params["#{_ransacker_aliases[search_attr]}_#{search_pred}"] = params.delete(k)
+            end
+          end
+
           Search.new(self, params, options)
         end
 

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -28,8 +28,8 @@ module Ransack
 
         def params_with_ransacker_aliases(params)
           params.keys.each do |k|
-            predicate = Predicate.detect_from_string(k)
-            attribute = k.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)
+            predicate = Predicate.detect_from_string(k.to_s)
+            attribute = k.to_s.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)
             if _ransacker_aliases.has_key?(attribute)
               normal_key = "#{_ransacker_aliases[attribute]}_#{predicate}"
               params[normal_key] = params.delete(k)

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -14,7 +14,7 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
-          Search.new(self, params, options)
+          Search.new(self, params_with_ransacker_aliases(params), options)
         end
 
         def ransacker(name, opts = {}, &block)
@@ -24,6 +24,18 @@ module Ransack
 
         def ransacker_alias(alias_name, normal_name)
           self._ransacker_aliases[alias_name.to_s] = normal_name.to_s
+        end
+
+        def params_with_ransacker_aliases(params)
+          params.keys.each do |k|
+            predicate = Predicate.detect_from_string(k)
+            attribute = k.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)            
+            if _ransacker_aliases.has_key?(attribute)
+              normal_key = "#{_ransacker_aliases[attribute]}_#{predicate}"
+              params[normal_key] = params.delete(k)
+            end
+          end
+          params
         end
 
         # Ransackable_attributes, by default, returns all column names

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -7,7 +7,9 @@ module Ransack
           alias :search :ransack unless base.respond_to? :search
           base.class_eval do
             class_attribute :_ransackers
+            class_attribute :_ransacker_aliases
             self._ransackers ||= {}
+            self._ransacker_aliases ||= {}
           end
         end
 
@@ -18,6 +20,10 @@ module Ransack
         def ransacker(name, opts = {}, &block)
           self._ransackers = _ransackers.merge name.to_s => Ransacker
             .new(self, name, opts, &block)
+        end
+        
+        def ransacker_alias(alias_name, normal_name)
+          self._ransacker_aliases[alias_name.to_s] = normal_name.to_s
         end
 
         # Ransackable_attributes, by default, returns all column names

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -21,7 +21,7 @@ module Ransack
           self._ransackers = _ransackers.merge name.to_s => Ransacker
             .new(self, name, opts, &block)
         end
-        
+
         def ransacker_alias(alias_name, normal_name)
           self._ransacker_aliases[alias_name.to_s] = normal_name.to_s
         end

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -29,7 +29,7 @@ module Ransack
         def params_with_ransacker_aliases(params)
           params.keys.each do |k|
             predicate = Predicate.detect_from_string(k)
-            attribute = k.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)            
+            attribute = k.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)
             if _ransacker_aliases.has_key?(attribute)
               normal_key = "#{_ransacker_aliases[attribute]}_#{predicate}"
               params[normal_key] = params.delete(k)

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -14,14 +14,6 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
-          params.keys.each do |k|
-            search_attr = k.to_s.sub(/_#{Ransack::Predicate.detect_from_string(k.to_s)}$/, Ransack::Constants::EMPTY)
-            search_pred = k.to_s.sub(/^#{search_attr}_/, Ransack::Constants::EMPTY)
-            if _ransacker_aliases.has_key?(search_attr)
-              params["#{_ransacker_aliases[search_attr]}_#{search_pred}"] = params.delete(k)
-            end
-          end
-
           Search.new(self, params, options)
         end
 

--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -7,7 +7,13 @@ module ActionView::Helpers::Tags
   class Base
     private
     def value(object)
-      object.send @method_name if object # use send instead of public_send
+      search_attr = @method_name.to_s.sub(/_#{Ransack::Predicate.detect_from_string(@method_name.to_s)}$/, Ransack::Constants::EMPTY)
+      search_pred = @method_name.to_s.sub(/^#{search_attr}_/, Ransack::Constants::EMPTY)
+	    if object.klass._ransacker_aliases.has_key?(search_attr)
+        object.send "#{object.klass._ransacker_aliases[search_attr]}_#{search_pred}" if object
+      else
+        object.send @method_name if object # use send instead of public_send
+      end
     end
   end
 end

--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -7,13 +7,7 @@ module ActionView::Helpers::Tags
   class Base
     private
     def value(object)
-      search_attr = @method_name.to_s.sub(/_#{Ransack::Predicate.detect_from_string(@method_name.to_s)}$/, Ransack::Constants::EMPTY)
-      search_pred = @method_name.to_s.sub(/^#{search_attr}_/, Ransack::Constants::EMPTY)
-	    if object.klass._ransacker_aliases.has_key?(search_attr)
-        object.send "#{object.klass._ransacker_aliases[search_attr]}_#{search_pred}" if object
-      else
-        object.send @method_name if object # use send instead of public_send
-      end
+      object.send @method_name if object # use send instead of public_send
     end
   end
 end

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -101,6 +101,16 @@ module Ransack
     def method_missing(method_id, *args)
       method_name = method_id.to_s
       getter_name = method_name.sub(/=$/, Constants::EMPTY)
+
+      # Check for ransacker aliases
+      predicate = Predicate.detect_from_string(getter_name)
+      attribute = getter_name.sub(/_#{predicate}$/, Ransack::Constants::EMPTY)
+      if klass._ransacker_aliases[attribute]
+        getter_name = klass._ransacker_aliases[attribute]
+        method_name = "#{getter_name}_#{predicate}"
+        method_id = method_name.to_sym
+      end
+
       if base.attribute_method?(getter_name)
         base.send(method_id, *args)
       elsif @context.ransackable_scope?(getter_name, @context.object)

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -335,7 +335,7 @@ module Ransack
             expect { s.result.first }.to_not raise_error
           end
         end
-        
+
         describe '#ransack_alias' do
           s1 = Person.ransack(cmnt_bd_cont: "some_words")
           s2 = Person.ransack(comments_body_cont: "some_words")

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -335,6 +335,12 @@ module Ransack
             expect { s.result.first }.to_not raise_error
           end
         end
+        
+        describe '#ransack_alias' do
+          s1 = Person.ransack(cmnt_bd_cont: "some_words")
+          s2 = Person.ransack(comments_body_cont: "some_words")
+          expect(s1.result.to_sql).to eq(s2.result.to_sql)
+        end
 
         describe '#ransackable_attributes' do
           context 'when auth_object is nil' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -81,6 +81,8 @@ class Person < ActiveRecord::Base
     SQL
     Arel.sql(query)
   end
+  
+  ransacker_alias :cmnt_bd, :comments_body
 
   def self.ransackable_attributes(auth_object = nil)
     if auth_object == :admin

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -81,7 +81,7 @@ class Person < ActiveRecord::Base
     SQL
     Arel.sql(query)
   end
-  
+
   ransacker_alias :cmnt_bd, :comments_body
 
   def self.ransackable_attributes(auth_object = nil)


### PR DESCRIPTION
Allow to alias (possibly long) search fields with (shorter) descriptions.
Works like ransacker, but uses already valid search fields, instead of requiring to write Arel.
Useful for converting long search fields to shorter, to save url length for GET requests.

Usage
```
class User
  translates :profile_text # from globalize gem
  has_many :works

  ransacker_alias :free_text, :translations_profile_text_or_works_translations_title_or_works_translations_description
end

User.search(free_text_cont: "some_text")
# same as User.search(translations_profile_text_or_works_translations_title_or_works_translations_description_cont: "some_text")
```
