### PR TITLE
ActiveRecord excludes Mongoid

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -2,11 +2,8 @@ require 'active_support/core_ext'
 
 require 'ransack/configuration'
 
-if defined?(::Mongoid)
-  require 'ransack/adapters/mongoid/ransack/constants'
-else
-  require 'ransack/adapters/active_record/ransack/constants'
-end
+require 'ransack/adapters'
+Ransack::Adapters.require_constants
 
 module Ransack
   extend Configuration
@@ -29,14 +26,6 @@ require 'action_controller'
 
 require 'ransack/translate'
 
-if defined?(::ActiveRecord::Base)
-  require 'ransack/adapters/active_record/ransack/translate'
-  require 'ransack/adapters/active_record'
-end
-
-if defined?(::Mongoid)
-  require 'ransack/adapters/mongoid/ransack/translate'
-  require 'ransack/adapters/mongoid'
-end
+Ransack::Adapters.require_adapter
 
 ActionController::Base.helper Ransack::Helpers::FormHelper

--- a/lib/ransack/adapters.rb
+++ b/lib/ransack/adapters.rb
@@ -1,0 +1,42 @@
+module Ransack
+  module Adapters
+
+    def self.current_adapters
+      @current_adapters ||= {
+        :active_record => defined?(::ActiveRecord::Base),
+        :mongoid => defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
+      }
+    end
+    def self.require_constants
+      require 'ransack/adapters/mongoid/ransack/constants' if current_adapters[:mongoid]
+      require 'ransack/adapters/active_record/ransack/constants' if current_adapters[:active_record]
+    end
+
+    def self.require_adapter
+      if current_adapters[:active_record]
+        require 'ransack/adapters/active_record/ransack/translate'
+        require 'ransack/adapters/active_record'
+      end
+
+      if current_adapters[:mongoid]
+        require 'ransack/adapters/mongoid/ransack/translate'
+        require 'ransack/adapters/mongoid'
+      end
+    end
+
+    def self.require_context
+      require 'ransack/adapters/active_record/ransack/visitor' if current_adapters[:active_record]
+      require 'ransack/adapters/mongoid/ransack/visitor' if current_adapters[:mongoid]
+    end
+
+    def self.require_nodes
+      require 'ransack/adapters/active_record/ransack/nodes/condition' if current_adapters[:active_record]
+      require 'ransack/adapters/mongoid/ransack/nodes/condition' if current_adapters[:mongoid]
+    end
+
+    def self.require_search
+      require 'ransack/adapters/active_record/ransack/context' if current_adapters[:active_record]
+      require 'ransack/adapters/mongoid/ransack/context' if current_adapters[:mongoid]
+    end
+  end
+end

--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -1,12 +1,5 @@
 require 'ransack/visitor'
-
-if defined?(::ActiveRecord::Base)
-  require 'ransack/adapters/active_record/ransack/visitor'
-end
-
-if defined?(::Mongoid)
-  require 'ransack/adapters/mongoid/ransack/visitor'
-end
+Ransack::Adapters.require_context
 
 module Ransack
   class Context

--- a/lib/ransack/nodes.rb
+++ b/lib/ransack/nodes.rb
@@ -3,7 +3,6 @@ require 'ransack/nodes/node'
 require 'ransack/nodes/attribute'
 require 'ransack/nodes/value'
 require 'ransack/nodes/condition'
-require 'ransack/adapters/active_record/ransack/nodes/condition' if defined?(::ActiveRecord::Base)
-require 'ransack/adapters/mongoid/ransack/nodes/condition' if defined?(::Mongoid)
+Ransack::Adapters.require_nodes
 require 'ransack/nodes/sort'
 require 'ransack/nodes/grouping'

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -1,14 +1,6 @@
 require 'ransack/nodes'
 require 'ransack/context'
-
-if defined?(::ActiveRecord::Base)
-  require 'ransack/adapters/active_record/ransack/context'
-end
-
-if defined?(::Mongoid)
-  require 'ransack/adapters/mongoid/ransack/context'
-end
-
+Ransack::Adapters.require_search
 require 'ransack/naming'
 
 module Ransack


### PR DESCRIPTION
Adapters overwrite each other, so they should not be required both