### PR TITLE
Avoid overwriting association conditions with default scope in Rails 3

### DIFF
--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -93,9 +93,10 @@ module Ransack
         expect(condition.value).to eq 'Ernie'
       end
 
-      it 'preserves default scope conditions for associations' do
-        search = Search.new(Person, articles_title_eq: 'Test')
+      it 'preserves default scope and conditions for associations' do
+        search = Search.new(Person, published_articles_title_eq: 'Test')
         expect(search.result.to_sql).to include 'default_scope'
+        expect(search.result.to_sql).to include 'published'
       end
 
       it 'discards empty conditions' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -33,6 +33,7 @@ class Person < ActiveRecord::Base
   belongs_to :parent, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :children, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :articles
+  has_many   :published_articles, :class_name => 'Article', :conditions => {published: true}
   has_many   :comments
   has_many   :authored_article_comments, :through => :articles,
              :source => :comments, :foreign_key => :person_id
@@ -171,6 +172,7 @@ module Schema
         t.string   :title
         t.text     :subject_header
         t.text     :body
+        t.boolean  :published, default: true
       end
 
       create_table :comments, :force => true do |t|

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -33,7 +33,11 @@ class Person < ActiveRecord::Base
   belongs_to :parent, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :children, :class_name => 'Person', :foreign_key => :parent_id
   has_many   :articles
-  has_many   :published_articles, :class_name => 'Article', :conditions => {published: true}
+  if ActiveRecord::VERSION::MAJOR == 3
+    has_many :published_articles, conditions: { published: true }, class_name: "Article"
+  else
+    has_many :published_articles, ->{ where(published: true) }, class_name: "Article"
+  end
   has_many   :comments
   has_many   :authored_article_comments, :through => :articles,
              :source => :comments, :foreign_key => :person_id


### PR DESCRIPTION
This is a fix on top of my previous pull request #426 where I fixed one bug but potentially introduced another. :speak_no_evil: 

When a model with default scope was associated with conditions (`has_many :x, conditions: ...`), the default scope would overwrite the association conditions. This patch ensures that both sources of conditions are applied.