### PR TITLE
Fix time-dependent test failure

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -145,6 +145,9 @@ module Ransack
           end
 
           it "should function correctly with a multi-parameter attribute" do
+            ::ActiveRecord::Base.default_timezone = :utc
+            Time.zone = 'UTC'
+
             date = Date.current
             s = Person.ransack(
               { "created_at_gteq(1i)" => date.year,


### PR DESCRIPTION
When the database has `default_timezone = :local` (system time) and the Time.zone is set to elsewhere then `Date.current` does not match what the query produces for the stored timestamps.

Resolved by setting everything to UTC.