### PR TITLE
Fix handling attribute-name with `_and_` `_or_`

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -31,7 +31,7 @@ module Ransack
 
         private
 
-        def extract_attributes_and_predicate(key, context=nil)
+        def extract_attributes_and_predicate(key, context = nil)
           str = key.dup
           name = Predicate.detect_and_strip_from_string!(str)
           predicate = Predicate.named(name)

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -9,7 +9,7 @@ module Ransack
 
       class << self
         def extract(context, key, values)
-          attributes, predicate = extract_attributes_and_predicate(key)
+          attributes, predicate = extract_attributes_and_predicate(key, context)
           if attributes.size > 0 && predicate
             combinator = key.match(/_(or|and)_/) ? $1 : nil
             condition = self.new(context)
@@ -31,14 +31,18 @@ module Ransack
 
         private
 
-        def extract_attributes_and_predicate(key)
+        def extract_attributes_and_predicate(key, context=nil)
           str = key.dup
           name = Predicate.detect_and_strip_from_string!(str)
           predicate = Predicate.named(name)
           unless predicate || Ransack.options[:ignore_unknown_conditions]
             raise ArgumentError, "No valid predicate for #{key}"
           end
-          attributes = str.split(/_and_|_or_/)
+          if context.present? && context.attribute_method?(str)
+            attributes = [str]
+          else
+            attributes = str.split(/_and_|_or_/)
+          end
           [attributes, predicate]
         end
       end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -228,14 +228,9 @@ module Ransack
           end
 
           it "should function correctly when an attribute name has 'and' in it" do
-          # FIXME: this test does not pass!
             p = Person.create!(:terms_and_conditions => true)
             s = Person.ransack(:terms_and_conditions_eq => true)
-          # search is not detecting the attribute
-            puts "
-            FIXME: Search not detecting the `terms_and_conditions` attribute in
-            base_spec.rb, line 178: #{s.result.to_sql}"
-          # expect(s.result.to_a).to eq [p]
+            expect(s.result.to_a).to eq [p]
           end
 
           it 'allows sort by "only_sort" field' do


### PR DESCRIPTION
This PR tries to resolve #299 

I think Ransack must recognize attribute\_name which includes `_and_` `_or_`.

My approach is:
If the model includes attribute\_name, Ransack should recognize it as one attribute\_name.

Please feedback this PR !!
