### PR TITLE
not requiring mongoid if activerecord is defined. This is so it works…

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext'
 
 require 'ransack/configuration'
 
-if defined?(::Mongoid)
+if defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
   require 'ransack/adapters/mongoid/ransack/constants'
 else
   require 'ransack/adapters/active_record/ransack/constants'
@@ -34,7 +34,7 @@ if defined?(::ActiveRecord::Base)
   require 'ransack/adapters/active_record'
 end
 
-if defined?(::Mongoid)
+if defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
   require 'ransack/adapters/mongoid/ransack/translate'
   require 'ransack/adapters/mongoid'
 end

--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -4,7 +4,7 @@ if defined?(::ActiveRecord::Base)
   require 'ransack/adapters/active_record/ransack/visitor'
 end
 
-if defined?(::Mongoid)
+if defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
   require 'ransack/adapters/mongoid/ransack/visitor'
 end
 

--- a/lib/ransack/nodes.rb
+++ b/lib/ransack/nodes.rb
@@ -4,6 +4,6 @@ require 'ransack/nodes/attribute'
 require 'ransack/nodes/value'
 require 'ransack/nodes/condition'
 require 'ransack/adapters/active_record/ransack/nodes/condition' if defined?(::ActiveRecord::Base)
-require 'ransack/adapters/mongoid/ransack/nodes/condition' if defined?(::Mongoid)
+require 'ransack/adapters/mongoid/ransack/nodes/condition' if defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
 require 'ransack/nodes/sort'
 require 'ransack/nodes/grouping'

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -5,7 +5,7 @@ if defined?(::ActiveRecord::Base)
   require 'ransack/adapters/active_record/ransack/context'
 end
 
-if defined?(::Mongoid)
+if defined?(::Mongoid) && !defined?(::ActiveRecord::Base)
   require 'ransack/adapters/mongoid/ransack/context'
 end
 


### PR DESCRIPTION
… by default with activerecord and activeadmin wont break.

This is because I have an application that have both activerecord and mongoid. The thing is that I am only listing activerecord models in my active admin, so there is no need for loading mongoid's ransack modules.