### PR TITLE
add functionality to hide all search indicator arrows via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ by adding this to an initializer like `config/initializers/ransack.rb`:
 
 ```ruby
 Ransack.configure do |c|
-  c.remove_search_order_indicators = true
+  c.hide_sort_order_indicators = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ The sort link may be displayed without the order indicator arrow by passing
 <%= sort_link(@q, :name, hide_indicator: true) %>
 ```
 
-Alternatively, all sort links may be displayed without the order indicator arrow by adding this to an initializer like config/initializers/ransack.rb:
+Alternatively, all sort links may be displayed without the order indicator arrow 
+by adding this to an initializer like `config/initializers/ransack.rb`:
 
 ```ruby
 Ransack.configure do |c|

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ The sort link may be displayed without the order indicator arrow by passing
 <%= sort_link(@q, :name, hide_indicator: true) %>
 ```
 
+Alternatively, all sort links may be displayed without the order indicator arrow by adding this to an initializer like config/initializers/ransack.rb:
+
+```ruby
+Ransack.configure do |c|
+  c.remove_search_order_indicators = true
+end
+```
+
 ### Advanced Mode
 
 "Advanced" searches (ab)use Rails' nested attributes functionality in order to

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -9,7 +9,7 @@ module Ransack
     self.options = {
       :search_key => :q,
       :ignore_unknown_conditions => true,
-      :remove_search_order_indicators => false
+      :hide_sort_order_indicators => false
     }
 
     def configure
@@ -76,7 +76,7 @@ module Ransack
       end
     end
 
-    def remove_search_order_indicators=(boolean)
+    def hide_sort_order_indicators=(boolean)
       self.options[:remove_search_order_indicators] = boolean
     end
 

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -77,7 +77,7 @@ module Ransack
     end
 
     def hide_sort_order_indicators=(boolean)
-      self.options[:remove_search_order_indicators] = boolean
+      self.options[:hide_sort_order_indicators] = boolean
     end
 
   end

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -8,7 +8,8 @@ module Ransack
     self.predicates = {}
     self.options = {
       :search_key => :q,
-      :ignore_unknown_conditions => true
+      :ignore_unknown_conditions => true,
+      :remove_search_order_indicators => false
     }
 
     def configure
@@ -73,6 +74,10 @@ module Ransack
       else
         "#{arel_predicate}#{suffix}"
       end
+    end
+
+    def remove_search_order_indicators=(boolean)
+      self.options[:remove_search_order_indicators] = boolean
     end
 
   end

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -94,7 +94,7 @@ module Ransack
           @current_dir    = existing_sort_direction
           @label_text     = extract_label_and_mutate_args!(args)
           @options        = extract_options_and_mutate_args!(args)
-          @hide_indicator = indicator?
+          @hide_indicator = @options.delete :hide_indicator || Ransack.options[:hide_sort_order_indicators]
           @default_order  = @options.delete :default_order
         end
 
@@ -197,16 +197,9 @@ module Ransack
             end
           end
 
-          def indicator?
-            @options.delete :hide_indicator unless Ransack.options[:hide_sort_order_indicators]
-          end
-
           def order_indicator
-            if @hide_indicator || no_sort_direction_specified? 
-              nil
-            else
-              direction_arrow
-            end
+            return if @hide_indicator || no_sort_direction_specified?
+            direction_arrow
           end
 
           def no_sort_direction_specified?(dir = @current_dir)

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -198,7 +198,7 @@ module Ransack
           end
 
           def order_indicator
-            if @hide_indicator || no_sort_direction_specified?
+            if @hide_indicator || no_sort_direction_specified? || Ransack.options[:remove_search_order_indicators]
               nil
             else
               direction_arrow

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -94,7 +94,7 @@ module Ransack
           @current_dir    = existing_sort_direction
           @label_text     = extract_label_and_mutate_args!(args)
           @options        = extract_options_and_mutate_args!(args)
-          @hide_indicator = @options.delete :hide_indicator || Ransack.options[:hide_sort_order_indicators]
+          @hide_indicator = @options.delete(:hide_indicator) || Ransack.options[:hide_sort_order_indicators]
           @default_order  = @options.delete :default_order
         end
 

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -94,7 +94,7 @@ module Ransack
           @current_dir    = existing_sort_direction
           @label_text     = extract_label_and_mutate_args!(args)
           @options        = extract_options_and_mutate_args!(args)
-          @hide_indicator = @options.delete :hide_indicator
+          @hide_indicator = indicator?
           @default_order  = @options.delete :default_order
         end
 
@@ -197,8 +197,12 @@ module Ransack
             end
           end
 
+          def indicator?
+            @options.delete :hide_indicator unless Ransack.options[:hide_sort_order_indicators]
+          end
+
           def order_indicator
-            if @hide_indicator || no_sort_direction_specified? || Ransack.options[:remove_search_order_indicators]
+            if @hide_indicator || no_sort_direction_specified? 
               nil
             else
               direction_arrow

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -343,7 +343,7 @@ module Ransack
             hide_indicator: true
           )
         }
-        it { should match /Full Name/ }
+        it { should_not match /&#9660;|&#9650;/ }
       end
 
       describe '#sort_link with hide order indicator set to false' do
@@ -410,10 +410,10 @@ module Ransack
             controller: 'people'
           )
         }
-        it { should match /Full Name/ }
+        it { should_not match /&#9660;|&#9650;/ }
       end
 
-      describe '#search_form_for with config set to remove sort order indicators' do
+      describe '#search_form_for with config set to not remove sort order indicators' do
         before do
           Ransack.configure { |c| c.hide_sort_order_indicators = false }
         end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -399,6 +399,34 @@ module Ransack
         it { should match /example_name_eq/ }
       end
 
+      describe '#search_form_for with config set to remove search order indicators' do
+        before do
+          Ransack.configure { |c| c.remove_search_order_indicators = true }
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people'
+          )
+        }
+        it { should match /Full Name/ }
+      end
+
+      describe '#search_form_for with config set to remove search order indicators' do
+        before do
+          Ransack.configure { |c| c.remove_search_order_indicators = false }
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people'
+          )
+        }
+        it { should match /Full Name&nbsp;&#9660;/ }
+      end
+
     end
   end
 end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -358,6 +358,34 @@ module Ransack
         it { should match /Full Name&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with config set to remove sort order indicators' do
+        before do
+          Ransack.configure { |c| c.hide_sort_order_indicators = true }
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people'
+          )
+        }
+        it { should_not match /&#9660;|&#9650;/ }
+      end
+
+      describe '#sort_link with config set to not remove sort order indicators' do
+        before do
+          Ransack.configure { |c| c.hide_sort_order_indicators = false }
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people'
+          )
+        }
+        it { should match /Full Name&nbsp;&#9660;/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context
           .search_form_for(Person.search) {} }
@@ -398,35 +426,6 @@ module Ransack
         }
         it { should match /example_name_eq/ }
       end
-
-      describe '#search_form_for with config set to remove sort order indicators' do
-        before do
-          Ransack.configure { |c| c.hide_sort_order_indicators = true }
-        end
-        subject { @controller.view_context
-          .sort_link(
-            [:main_app, Person.search(sorts: ['name desc'])],
-            :name,
-            controller: 'people'
-          )
-        }
-        it { should_not match /&#9660;|&#9650;/ }
-      end
-
-      describe '#search_form_for with config set to not remove sort order indicators' do
-        before do
-          Ransack.configure { |c| c.hide_sort_order_indicators = false }
-        end
-        subject { @controller.view_context
-          .sort_link(
-            [:main_app, Person.search(sorts: ['name desc'])],
-            :name,
-            controller: 'people'
-          )
-        }
-        it { should match /Full Name&nbsp;&#9660;/ }
-      end
-
     end
   end
 end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -413,11 +413,7 @@ module Ransack
         it { should match /Full Name/ }
       end
 
-<<<<<<< HEAD
       describe '#search_form_for with config set to remove sort order indicators' do
-=======
-      describe '#search_form_for with config set to not remove search order indicators' do
->>>>>>> aad81baf6130f0fa13cfabdb4dedcd25f0297b8c
         before do
           Ransack.configure { |c| c.hide_sort_order_indicators = false }
         end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -399,9 +399,9 @@ module Ransack
         it { should match /example_name_eq/ }
       end
 
-      describe '#search_form_for with config set to remove search order indicators' do
+      describe '#search_form_for with config set to remove sort order indicators' do
         before do
-          Ransack.configure { |c| c.remove_search_order_indicators = true }
+          Ransack.configure { |c| c.hide_sort_order_indicators = true }
         end
         subject { @controller.view_context
           .sort_link(
@@ -413,9 +413,9 @@ module Ransack
         it { should match /Full Name/ }
       end
 
-      describe '#search_form_for with config set to remove search order indicators' do
+      describe '#search_form_for with config set to remove sort order indicators' do
         before do
-          Ransack.configure { |c| c.remove_search_order_indicators = false }
+          Ransack.configure { |c| c.hide_sort_order_indicators = false }
         end
         subject { @controller.view_context
           .sort_link(


### PR DESCRIPTION
config/initializer/ransack.rb

Ransack.configure do |c|
  c.remove_search_order_indicators = true
end

This is basically like passing 'hide_indicator: true' to all of your search indicators..without passing it to all of your search indicators.