### PR TITLE
Bugfix for in/not_in predicates incorrectly casting arrays to strings

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -93,10 +93,7 @@ module Ransack
             self.values << val
           end
         when Hash
-          args.each do |index, attrs|
-            val = Value.new(@context, attrs[:value])
-            self.values << val
-          end
+          self.values = args.values.map { |a| a[:value] }.flatten
         else
           raise ArgumentError,
             "Invalid argument (#{args.class}) supplied to values="

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -82,6 +82,23 @@ module Ransack
         expect(Ransack.predicates['test_not_in_predicate'].wants_array).to eq true
       end
 
+      it 'wants an array for in/not_in predicates from a search form' do
+        dick = Person.create!(name: 'Dick')
+        Person.create!(name: 'Jane')
+
+        people = Person.ransack(
+          'c' => {
+            '0' => {
+              'v' => { '0' => { 'value' => ['Dick'] } },
+              'a' => { '0' => { 'name' => 'name' } },
+              'p' => 'in'
+            }
+          }
+        ).result
+
+        expect(people).to eq([dick])
+      end
+
       it 'explicitly does not want array for in/not_in predicates' do
         Ransack.configure do |config|
           config.add_predicate(


### PR DESCRIPTION
When submitting a search form containing an `in` or `not_in` predicate search, the passed array value is incorrectly cast to a string before being included in the resulting SQL query.
## Actual:

``` sql
SELECT "people".* FROM "people" WHERE "people"."name" IN ('["Dick", "Jane"]');
```
## Expected:

``` sql
SELECT "people".* FROM "people" WHERE "people"."name" IN ('Dick', 'Jane');
```
