### PR TITLE
Fixed: Rails 4.2: NoMethodError: undefined method 'asc' for #<Arel::N…

### DIFF
--- a/lib/ransack/visitor.rb
+++ b/lib/ransack/visitor.rb
@@ -44,7 +44,12 @@ module Ransack
     end
 
     def visit_Ransack_Nodes_Sort(object)
-      object.attr.send(object.dir) if object.valid?
+      return unless object.valid?
+      if object.attr.is_a? Arel::Attributes::Attribute
+        object.attr.send(object.dir)
+      else
+        ordered object
+      end
     end
 
     def quoted?(object)
@@ -64,5 +69,15 @@ module Ransack
       hash[klass] = "visit_#{klass.name.gsub('::', '_')}"
     end
 
+    private
+
+      def ordered(object)
+        case object.dir
+        when 'asc'.freeze
+          Arel::Nodes::Ascending.new(object.attr)
+        when 'desc'.freeze
+          Arel::Nodes::Descending.new(object.attr)
+        end
+      end
   end
 end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -164,6 +164,29 @@ module Ransack
             )
           end
 
+          context 'case insensitive sorting' do
+            it 'allows sort by desc' do
+              search = Person.search(sorts: ['name_case_insensitive desc'])
+              expect(search.result.to_sql).to match /ORDER BY LOWER(.*) DESC/
+            end
+
+            it 'allows sort by asc' do
+              search = Person.search(sorts: ['name_case_insensitive asc'])
+              expect(search.result.to_sql).to match /ORDER BY LOWER(.*) ASC/
+            end
+          end
+
+          context 'regular sorting' do
+            it 'allows sort by desc' do
+              search = Person.search(sorts: ['name desc'])
+              expect(search.result.to_sql).to match /ORDER BY .* DESC/
+            end
+
+            it 'allows sort by asc' do
+              search = Person.search(sorts: ['name asc'])
+              expect(search.result.to_sql).to match /ORDER BY .* ASC/
+            end
+          end
         end
 
         describe '#ransackable_attributes' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -55,6 +55,10 @@ class Person < ActiveRecord::Base
       )
   end
 
+  ransacker :name_case_insensitive, type: :string do
+    arel_table[:name].lower
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     if auth_object == :admin
       column_names + _ransackers.keys - ['only_sort']


### PR DESCRIPTION
Fixed issue with Rails 4.2: NoMethodError: undefined method 'asc' for #<Arel::Nodes::NamedFunction... #483

Implemented wrapping of Arel::Nodes::NamedFunction for asc/desc case accordingly to Arel 6.0. 