### PR TITLE
Fixed: Rails 4.2: NoMethodError: undefined method asc for #<Arel::Nod…

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/visitor.rb
+++ b/lib/ransack/adapters/active_record/ransack/visitor.rb
@@ -20,5 +20,24 @@ module Ransack
       end
     end
 
+    def visit_Ransack_Nodes_Sort(object)
+      return unless object.valid?
+      if object.attr.is_a?(Arel::Attributes::Attribute)
+        object.attr.send(object.dir)
+      else
+        ordered(object)
+      end
+    end
+
+    private
+
+      def ordered(object)
+        case object.dir
+        when 'asc'.freeze
+          Arel::Nodes::Ascending.new(object.attr)
+        when 'desc'.freeze
+          Arel::Nodes::Descending.new(object.attr)
+        end
+      end
   end
 end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -544,6 +544,30 @@ module Ransack
               /BETWEEN 2 AND 6 GROUP BY articles.person_id \) DESC/
             )
           end
+
+          context 'case insensitive sorting' do
+            it 'allows sort by desc' do
+              search = Person.search(sorts: ['name_case_insensitive desc'])
+              expect(search.result.to_sql).to match /ORDER BY LOWER(.*) DESC/
+            end
+
+            it 'allows sort by asc' do
+              search = Person.search(sorts: ['name_case_insensitive asc'])
+              expect(search.result.to_sql).to match /ORDER BY LOWER(.*) ASC/
+            end
+          end
+
+          context 'regular sorting' do
+            it 'allows sort by desc' do
+              search = Person.search(sorts: ['name desc'])
+              expect(search.result.to_sql).to match /ORDER BY .* DESC/
+            end
+
+            it 'allows sort by asc' do
+              search = Person.search(sorts: ['name asc'])
+              expect(search.result.to_sql).to match /ORDER BY .* ASC/
+            end
+          end
         end
 
         describe '#ransackable_attributes' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -96,6 +96,10 @@ class Person < ActiveRecord::Base
     Arel.sql('people.id')
   end
 
+  ransacker :name_case_insensitive, type: :string do
+    arel_table[:name].lower
+  end
+
   ransacker :with_arguments, args: [:parent, :ransacker_args] do |parent, args|
     min, max = args
     query = <<-SQL


### PR DESCRIPTION
This pull request fixes the issue: Rails 4.2: NoMethodError: undefined method `asc' for #<Arel::Nodes::NamedFunction... #483
