### PR TITLE
Fixes aliased attributes in association searches

### DIFF
--- a/lib/ransack/nodes/bindable.rb
+++ b/lib/ransack/nodes/bindable.rb
@@ -37,7 +37,7 @@ module Ransack
 
       def get_attribute
         if is_alias_attribute?
-          context.table_for(parent)[context.klass.attribute_aliases[attr_name]]
+          context.table_for(parent)[parent.base_klass.attribute_aliases[attr_name]]
         else
           context.table_for(parent)[attr_name]
         end
@@ -45,7 +45,7 @@ module Ransack
 
       def is_alias_attribute?
         Ransack::SUPPORTS_ATTRIBUTE_ALIAS &&
-        context.klass.attribute_aliases.key?(attr_name)
+        parent.base_klass.attribute_aliases.key?(attr_name)
       end
     end
   end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -274,12 +274,22 @@ module Ransack
             expect(s.result.to_a).to eq [p]
           end
 
-          it 'should translate attribute aliased column names',
+          context 'attribute aliased column names',
           if: Ransack::SUPPORTS_ATTRIBUTE_ALIAS do
-            s = Person.ransack(full_name_eq: 'Nicolas Cage')
-            expect(s.result.to_sql).to match(
-              /WHERE #{quote_table_name("people")}.#{quote_column_name("name")}/
-            )
+            it 'should be translated to original column name' do
+              s = Person.ransack(full_name_eq: 'Nicolas Cage')
+              expect(s.result.to_sql).to match(
+                /WHERE #{quote_table_name("people")}.#{quote_column_name("name")}/
+              )
+            end
+
+            it 'should translate on associations' do
+              s = Person.ransack(articles_content_cont: 'Nicolas Cage')
+              expect(s.result.to_sql).to match(
+                /#{quote_table_name("articles")}.#{
+                   quote_column_name("body")} I?LIKE '%Nicolas Cage%'/
+              )
+            end
           end
 
           it 'allows sort by `only_sort` field' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -113,6 +113,8 @@ class Article < ActiveRecord::Base
   has_and_belongs_to_many :tags
   has_many :notes, as: :notable
 
+  alias_attribute :content, :body
+
   if ActiveRecord::VERSION::STRING >= '3.1'
     default_scope { where("'default_scope' = 'default_scope'") }
   else # Rails 3.0 does not accept a block


### PR DESCRIPTION
Aliased attributes on associations searches (e.g: `articles_content_cont`) did not work, I added a failing test and then implemented a fix.