### PR TITLE
Add block argument for sort_link

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -38,12 +38,19 @@ module Ransack
       #
       #   <%= sort_link(@q, :name, [:name, 'kind ASC'], 'Player Name') %>
       #
-      def sort_link(search_object, attribute, *args)
+      # You can use a block as well if your link target is hard to fit into the label parameter:
+      #
+      #   <%= sort_link(@q, :name, [:name, 'kind ASC']) do %>
+      #     <strong>Player Name</strong>
+      #   <% end %>
+      #
+      def sort_link(search_object, attribute, *args, &block)
         search, routing_proxy = extract_search_and_routing_proxy(search_object)
         unless Search === search
           raise TypeError, 'First argument must be a Ransack::Search!'
         end
-        s = SortLink.new(search, attribute, args, params)
+        args.unshift(capture(&block)) if block_given?
+        s = SortLink.new(search, attribute, args, params, &block)
         link_to(s.name, url(routing_proxy, s.url_options), s.html_options(args))
       end
 

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -382,6 +382,20 @@ module Ransack
         it { should match /Full Name&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with a block' do
+        before do
+          Ransack.configure { |c| c.hide_sort_order_indicators = false }
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people'
+          ) { 'Block label' }
+        }
+        it { should match /Block label&nbsp;&#9660;/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context
           .search_form_for(Person.search) {} }


### PR DESCRIPTION
Allow passing block argument to the sort_link method:

```ruby
<%= sort_link(@q, :name, [:name, 'kind ASC']) do %>
  <strong>Player Name</strong>
<% end %>
```