### PR TITLE
Rails 5 params: instance_variable_get -> to_unsafe_h

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -86,7 +86,7 @@ module Ransack
       class SortLink
         def initialize(search, attribute, args, params)
           @search         = search
-          @params         = parameters_hash(params)
+          @params         = params.respond_to?(:to_unsafe_h) ? params.to_unsafe_h : params
           @field          = attribute.to_s
           @sort_fields    = extract_sort_fields_and_mutate_args!(args).compact
           @current_dir    = existing_sort_direction
@@ -120,11 +120,6 @@ module Ransack
 
         private
 
-          def parameters_hash(params)
-            return params unless params.instance_variable_defined?(:@parameters)
-            params.instance_variable_get(:@parameters)
-          end
-
           def extract_sort_fields_and_mutate_args!(args)
             return args.shift if args[0].is_a?(Array)
             [@field]
@@ -145,7 +140,7 @@ module Ransack
           end
 
           def search_params
-            parameters_hash(@params[@search.context.search_key]).presence || {}
+            @params[@search.context.search_key].presence || {}
           end
 
           def sort_params

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -15,9 +15,7 @@ module Ransack
              :translate, :to => :base
 
     def initialize(object, params = {}, options = {})
-      if params.instance_variable_defined?(:@parameters)
-        params = params.instance_variable_get :@parameters
-      end
+      params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
       if params.is_a? Hash
         params = params.dup
         params.delete_if { |k, v| [*v].all?{ |i| i.blank? && i != false } }


### PR DESCRIPTION
`search_params` didn’t need this behavior because it’s using the `@params` variable that’s already ready for use