### PR TITLE
Fix missing search params for sort link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@
 
     *Ethan Yang*
 
+*   Fix recent change to sort_links parameter_hash to account for symbol search
+    keys. Add test using real AC:Parameter object.
+    Commit [989d](https://github.com/activerecord-hackery/ransack/commit/989d)
+
+    *Ryan Wood*
+
 ### Changed
 
 *   Memory/speed perf improvement: Freeze strings in array global constants and

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -122,7 +122,7 @@ module Ransack
 
           def parameters_hash(params)
             return params unless params.respond_to?(:to_unsafe_h)
-            params.to_unsafe_h
+            params.to_unsafe_h.with_indifferent_access
           end
 
           def extract_sort_fields_and_mutate_args!(args)

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -311,10 +311,11 @@ module Ransack
       end
 
       context 'view has existing parameters' do
-        before do
-          @controller.view_context.params.merge!({ exist: 'existing' })
-        end
         describe '#sort_link should not remove existing params' do
+          before do
+            @controller.view_context.params.merge!({ exist: 'existing' })
+          end
+
           subject { @controller.view_context
             .sort_link(
               Person.search(
@@ -326,6 +327,34 @@ module Ransack
             )
           }
           it { should match /exist\=existing/ }
+        end
+
+        context('using real ActionController Parameter object') do
+          describe '#sort_link should include search params' do
+            subject { @controller.view_context
+              .sort_link(
+                Person.search,
+                :name,
+              )
+            }
+            let(:params) {
+              ActionController::Parameters.new(
+                {
+                  q: { name_eq: 'TEST' },
+                  controller: 'people',
+                }
+              )
+            }
+            before do
+              @controller.instance_variable_set(:@params, params)
+            end
+            it {
+              should match(
+                /people\?q(%5B|\[)name_eq(%5D|\])=TEST&amp;q(%5B|\[)s(%5D|\])
+                =name\+asc/x,
+               )
+            }
+          end
         end
       end
 


### PR DESCRIPTION
Problem:
- The controller params are no longer being passed into ransack's sort_link. The culprit is a recent change to `SortLinks` internal parameter hash. It is taking the controller's parameter object and converting it to a regular hash in which all the keys are strings. During the assembly of the sort link, the code is then attempting to extract the search params using the default key of `:q` (or whatever what was configured by the user). 

I added a test that is using the real AC::Parameter object so that this bug could be caught. I `fixed` my personal app by changing the search key to `'q'` though I feel that change is a hack until this PR has been addressed.

Bug introduced here: [989d](https://github.com/activerecord-hackery/ransack/commit/989d)