### PR TITLE
Respect negative conditions for collection associations

### DIFF
--- a/lib/ransack/adapters/active_record.rb
+++ b/lib/ransack/adapters/active_record.rb
@@ -1,6 +1,8 @@
 require 'ransack/adapters/active_record/base'
 ActiveRecord::Base.extend Ransack::Adapters::ActiveRecord::Base
 
+require 'ransack/adapters/active_record/context'
+
 case ActiveRecord::VERSION::STRING
 when /^3\.0\./
   require 'ransack/adapters/active_record/3.0/context'
@@ -8,6 +10,4 @@ when /^3\.1\./
   require 'ransack/adapters/active_record/3.1/context'
 when /^3\.2\./
   require 'ransack/adapters/active_record/3.2/context'
-else
-  require 'ransack/adapters/active_record/context'
 end

--- a/lib/ransack/adapters/active_record/3.0/context.rb
+++ b/lib/ransack/adapters/active_record/3.0/context.rb
@@ -7,9 +7,11 @@ module Ransack
   module Adapters
     module ActiveRecord
       class Context < ::Ransack::Context
+
         # Because the AR::Associations namespace is insane
-        JoinDependency = ::ActiveRecord::Associations::ClassMethods::JoinDependency
-        JoinBase = JoinDependency::JoinBase
+        if defined? ::ActiveRecord::Associations::ClassMethods::JoinDependency
+          JoinDependency = ::ActiveRecord::Associations::ClassMethods::JoinDependency
+        end
 
         # Redefine a few things for ActiveRecord 3.0.
 

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -6,8 +6,6 @@ module Ransack
   module Adapters
     module ActiveRecord
       class Context < ::Ransack::Context
-        # Because the AR::Associations namespace is insane
-        JoinDependency = ::ActiveRecord::Associations::JoinDependency
 
         # Redefine a few things for ActiveRecord 3.1.
 

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -8,7 +8,6 @@ module Ransack
       class Context < ::Ransack::Context
         # Because the AR::Associations namespace is insane
         JoinDependency = ::ActiveRecord::Associations::JoinDependency
-        JoinPart = JoinDependency::JoinPart
 
         # Redefine a few things for ActiveRecord 3.1.
 

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -9,7 +9,6 @@ module Ransack
 
         # Because the AR::Associations namespace is insane
         JoinDependency = ::ActiveRecord::Associations::JoinDependency
-        JoinPart = JoinDependency::JoinPart
 
         def initialize(object, options = {})
           super

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -8,7 +8,9 @@ module Ransack
       class Context < ::Ransack::Context
 
         # Because the AR::Associations namespace is insane
-        JoinDependency = ::ActiveRecord::Associations::JoinDependency
+        if defined? ::ActiveRecord::Associations::JoinDependency
+          JoinDependency = ::ActiveRecord::Associations::JoinDependency
+        end
 
         def initialize(object, options = {})
           super

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -15,6 +15,7 @@ module Ransack
         def initialize(object, options = {})
           super
           @arel_visitor = @engine.connection.visitor
+          @associations_pot = {}
         end
 
         def relation_for(object)
@@ -252,7 +253,7 @@ module Ransack
           def find_association(name, parent = @base, klass = nil)
             @join_dependency.join_root.children.detect do |assoc|
               assoc.reflection.name == name &&
-              (@associations_pot.nil? || @associations_pot[assoc] == parent) &&
+              (@associations_pot.empty? || @associations_pot[assoc] == parent) &&
               (!klass || assoc.reflection.klass == klass)
             end
           end
@@ -264,7 +265,7 @@ module Ransack
               []
             )
             found_association = jd.join_root.children.last
-            associations found_association, parent
+            @associations_pot[found_association] = parent
 
             # TODO maybe we dont need to push associations here, we could loop
             # through the @associations_pot instead
@@ -279,11 +280,6 @@ module Ransack
             @object = @object.joins(jd)
 
             found_association
-          end
-
-          def associations(assoc, parent)
-            @associations_pot ||= {}
-            @associations_pot[assoc] = parent
           end
 
         else

--- a/lib/ransack/adapters/active_record/ransack/context.rb
+++ b/lib/ransack/adapters/active_record/ransack/context.rb
@@ -40,7 +40,7 @@ module Ransack
         @base.table_name, as: @base.aliased_table_name, type_caster: self
         )
       @bind_pairs = Hash.new do |hash, key|
-        parent, attr_name = get_parent_and_attribute_name(key.to_s)
+        parent, attr_name = get_parent_and_attribute_name(key)
         if parent && attr_name
           hash[key] = [parent, attr_name]
         end

--- a/lib/ransack/adapters/active_record/ransack/context.rb
+++ b/lib/ransack/adapters/active_record/ransack/context.rb
@@ -27,6 +27,8 @@ module Ransack
       @join_dependency = join_dependency(@object)
       @join_type = options[:join_type] || Polyamorous::OuterJoin
       @search_key = options[:search_key] || Ransack.options[:search_key]
+      @associations_pot = {}
+      @lock_associations = []
 
       if ::ActiveRecord::VERSION::STRING >= Constants::RAILS_4_1
         @base = @join_dependency.join_root

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -4,15 +4,15 @@ module Ransack
 
       def arel_predicate
         if attributes.size > 1
-          combinator_for(attributes_array)
+          combinator_for_predicates
         else
-          format_predicate(attributes_array.first)
+          format_predicate
         end
       end
 
       private
 
-        def attributes_array
+        def arel_predicates
           attributes.map do |a|
             a.attr.send(
               arel_predicate_for_attribute(a), formatted_values_for_attribute(a)
@@ -20,20 +20,20 @@ module Ransack
           end
         end
 
-        def combinator_for(predicates)
+        def combinator_for_predicates
           if combinator === Constants::AND
-            Arel::Nodes::Grouping.new(Arel::Nodes::And.new(predicates))
+            Arel::Nodes::Grouping.new(arel_predicates.inject(&:and))
           elsif combinator === Constants::OR
-            predicates.inject(&:or)
+            arel_predicates.inject(&:or)
           end
         end
 
-        def format_predicate(predicate)
-          predicate.tap do
-            if casted_array_with_in_predicate?(predicate)
-              predicate.right[0] = format_values_for(predicate.right[0])
-            end
+        def format_predicate
+          predicate = arel_predicates.first
+          if casted_array_with_in_predicate?(predicate)
+            predicate.right[0] = format_values_for(predicate.right[0])
           end
+          predicate
         end
 
         def casted_array_with_in_predicate?(predicate)

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -3,7 +3,11 @@ module Ransack
     class Condition
 
       def arel_predicate
-        arel_predicate_for(attributes_array)
+        if attributes.size > 1
+          combinator_for(attributes_array)
+        else
+          format_predicate(attributes_array.first)
+        end
       end
 
       private
@@ -13,14 +17,6 @@ module Ransack
             a.attr.send(
               arel_predicate_for_attribute(a), formatted_values_for_attribute(a)
             )
-          end
-        end
-
-        def arel_predicate_for(predicates)
-          if predicates.size > 1
-            combinator_for(predicates)
-          else
-            format_predicate(predicates.first)
           end
         end
 

--- a/lib/ransack/adapters/mongoid/context.rb
+++ b/lib/ransack/adapters/mongoid/context.rb
@@ -6,10 +6,6 @@ module Ransack
     module Mongoid
       class Context < ::Ransack::Context
 
-        # Because the AR::Associations namespace is insane
-        # JoinDependency = ::Mongoid::Associations::JoinDependency
-        # JoinPart = JoinDependency::JoinPart
-
         def initialize(object, options = {})
           super
           # @arel_visitor = @engine.connection.visitor

--- a/lib/ransack/adapters/mongoid/context.rb
+++ b/lib/ransack/adapters/mongoid/context.rb
@@ -96,6 +96,14 @@ module Ransack
           end
         end
 
+        def lock_association(association)
+          warn "lock_association is not implemented for Ransack mongoid adapter" if $DEBUG
+        end
+
+        def remove_association(association)
+          warn "remove_association is not implemented for Ransack mongoid adapter" if $DEBUG
+        end
+
       private
 
         def get_parent_and_attribute_name(str, parent = @base)

--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -58,6 +58,7 @@ module Ransack
     end
 
     def bind(object, str)
+      return nil unless str
       object.parent, object.attr_name = @bind_pairs[str]
     end
 

--- a/lib/ransack/nodes/attribute.rb
+++ b/lib/ransack/nodes/attribute.rb
@@ -16,7 +16,6 @@ module Ransack
 
       def name=(name)
         @name = name
-        context.bind(self, name) unless name.blank?
       end
 
       def valid?

--- a/lib/ransack/nodes/attribute.rb
+++ b/lib/ransack/nodes/attribute.rb
@@ -24,6 +24,10 @@ module Ransack
         .include?(attr_name.split('.').last)
       end
 
+      def associated_collection?
+        parent.respond_to?(:reflection) && parent.reflection.collection?
+      end
+
       def type
         if ransacker
           return ransacker.type

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -247,6 +247,10 @@ module Ransack
         "Condition <#{data}>"
       end
 
+      def negative?
+        predicate.negative?
+      end
+
       private
 
       def valid_combinator?

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -131,6 +131,9 @@ module Ransack
         Attribute.new(@context, name, ransacker_args).tap do |attribute|
           @context.bind(attribute, attribute.name)
           self.attributes << attribute if attribute.valid?
+          if predicate && !negative?
+            @context.lock_association(attribute.parent)
+          end
         end
       end
 
@@ -182,6 +185,10 @@ module Ransack
 
       def predicate_name=(name)
         self.predicate = Predicate.named(name)
+        unless negative?
+          attributes.each { |a| context.lock_association(a.parent) }
+        end
+        @predicate
       end
       alias :p= :predicate_name=
 

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -79,14 +79,12 @@ module Ransack
       def attributes=(args)
         case args
         when Array
-          args.each do |attr|
-            attr = Attribute.new(@context, attr)
-            self.attributes << attr if attr.valid?
+          args.each do |name|
+            build_attribute(name)
           end
         when Hash
           args.each do |index, attrs|
-            attr = Attribute.new(@context, attrs[:name], attrs[:ransacker_args])
-            self.attributes << attr if attr.valid?
+            build_attribute(attrs[:name], attrs[:ransacker_args])
           end
         else
           raise ArgumentError,
@@ -129,9 +127,10 @@ module Ransack
       alias :m= :combinator=
       alias :m :combinator
 
-      def build_attribute(name = nil)
-        Attribute.new(@context, name).tap do |attribute|
-          self.attributes << attribute
+      def build_attribute(name = nil, ransacker_args = [])
+        Attribute.new(@context, name, ransacker_args).tap do |attribute|
+          @context.bind(attribute, attribute.name)
+          self.attributes << attribute if attribute.valid?
         end
       end
 

--- a/lib/ransack/nodes/sort.rb
+++ b/lib/ransack/nodes/sort.rb
@@ -32,7 +32,7 @@ module Ransack
 
       def name=(name)
         @name = name
-        context.bind(self, name) unless name.blank?
+        context.bind(self, name)
       end
 
       def dir=(dir)

--- a/lib/ransack/predicate.rb
+++ b/lib/ransack/predicate.rb
@@ -74,5 +74,9 @@ module Ransack
       vals.any? { |v| validator.call(type ? v.cast(type) : v.value) }
     end
 
+    def negative?
+      @name.include?("not_".freeze)
+    end
+
   end
 end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -312,7 +312,7 @@ module Ransack
 
       context 'view has existing parameters' do
         before do
-          @controller.view_context.params.merge!({ exist: 'existing' })
+          @controller.view_context.params[:exist] = 'existing'
         end
         describe '#sort_link should not remove existing params' do
           subject { @controller.view_context

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -29,6 +29,15 @@ module Ransack
         specify { expect(subject.values.size).to eq(2) }
       end
 
+      describe '#negative?' do
+        let(:context) { Context.for(Person) }
+        let(:eq)      { Condition.extract(context, 'name_eq', 'A') }
+        let(:not_eq)  { Condition.extract(context, 'name_not_eq', 'A') }
+
+        specify { expect(not_eq.negative?).to be true }
+        specify { expect(eq.negative?).to be false }
+      end
+
       context 'with an invalid predicate' do
         subject {
           Condition.extract(


### PR DESCRIPTION
When searching against attributes from a collection association (`has_many` / `:through` / `has_and_belongs_to_many`), a normal JOIN will include false positives when asking to exclude values (`!=`, `NOT IN`, `IS NOT NULL`) and another tuple is matched.

This is the basic case, see specs for details:

* A book exists with two tags: "medieval" and "fantasy"
* You search for books that are NOT "fantasy"
* The result would still include it, because it matches the other tag for NOT "fantasy"

In situations where this would happen, I've moved the `LEFT OUTER JOIN` into a subquery with inverted conditions. This is implemented with a correlated primary key which should help the query plan to avoid scanning entire tables in the subquery. The conditions now look like this:

```
WHERE root.id NOT IN (
  SELECT child.parent_id FROM child
   ... WHERE ... AND child.parent_id = root.id
)
```

Note that root.id is referenced in the inner query. The EXPLAIN query plan for this looks sensible, at least in MySQL where I explored it.

As far as I know this works with all standard ActiveRecord joins: I have not yet verified with composite keys or polymorphic joins or Nth-degree associations but it should be close to working if it isn't already.

I will start testing this against our own real-world data to see how it performs, please check it out too.

### Known issues:

- [x] Fix mongoid tests failures.
- [ ] Errors with `not_null` predicate: seems like a positive case and should use the original code branch.