### PR TITLE
Ransack::Search#respond_to?

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -91,6 +91,10 @@ module Ransack
       Nodes::Sort.new(@context).build(opts)
     end
 
+    def respond_to?(method_id)
+      super || base.respond_to?(method_id)
+    end
+
     def method_missing(method_id, *args)
       method_name = method_id.to_s
       getter_name = method_name.sub(/=$/, ''.freeze)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -439,6 +439,24 @@ module Ransack
       end
     end
 
+    describe '#respond_to?' do
+      before do
+        @s = Search.new(Person)
+      end
+
+      it 'won\'t respond to invalid attributes' do
+        expect(@s.respond_to?(:blah)).to be false
+      end
+
+      it 'will respond to valid attributes' do
+        expect(@s.respond_to?(:name_eq)).to be true
+      end
+
+      it 'will respond to a search\'s own methods' do
+        expect(@s.respond_to?(:result)).to be true
+      end
+    end
+
     describe '#method_missing' do
       before do
         @s = Search.new(Person)


### PR DESCRIPTION
Attempting to match `respond_to?` result with `method_missing` behaviour.
Fails FormBuilder polymorphic relations tests however.

I'm afraid I'm a bit stuck with where to go from here - the initial assertion, that a Search will also respond to its Grouping's methods (per `method_missing`) seems sound, but tests involving polymorphism start failing.
