### PR TITLE
Add list of predicates to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,35 @@ query parameters in your URLs.
 <% end %>
 ```
 
+### Search Matchers
+
+List of all possible predicates
+
+* `*_eq` - equal
+* `*_not_eq` - not equal
+* `*_match` - matches with `LIKE`, e.g. `q[email_matches]=%@gmail.com`
+* Also: `*_does_not_match`, `*_matches_any`, `*_matches_all`, `*_does_not_match_any`, `*_does_not_match_all`
+* `*_lt` - less then
+* `*_lteq` - less then or equal
+* `*_gt` - greater than
+* `*_gteq` - greater than or equal
+* `*_present` - not null and not empty, e.g. `q[name_present]=1` (SQL: `col is not null AND col != ''`)
+* `*_bank` - is null or empty. (SQL: `col is null OR col = ''`)
+* `*_null`, `*_not_null` - is null, is not null
+* `*_in` - match any values in array, e.g. `q[name_in][]=Alice&q[name_in][]=Bob`
+* `*_not_in` - match none of values in array
+* `*_lt_any`, `*_lteq_any`, `*_gt_any`, `*_gteq_any` - Compare to list of values, at least positive. (SQL: `col > value1 OR col > value2`)
+* `*_matches_any`, `*_does_not_match_any` - same as above but with `LIKE`
+* `*_lt_all`, `*_lteq_all`, `*_gt_all`, `*_gteq_all` - Compare to list of values, all positive. (SQL: `col > value1 AND col > value2`)
+* `*_matches_all`, `*_does_not_match_all` - same as above but with `LIKE`
+* `*_not_eq_all` - none of values in a set
+* `*_start`, `*_not_start`, `*_start_any`, `*_start_all`, `*_not_start_any`, `*_not_start_all` - start with, (SQL: `col LIKE 'value%'`)
+* `*_end`, `*_not_end`, `*_end_any`, `*_end_all`, `*_not_end_any`, `*_not_end_all` - end with, (SQL: `col LIKE '%value'`)
+* `*_cont`, `*_cont_any`, `*_cont_all`, `*_not_cont`, `*_not_cont_any`, `*_not_cont_all` - contains value, using `LIKE`
+* `*_true`, `*_false` - is true and is false
+
+(See full list: https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/locale/en.yml#L15)
+
 ### Using Ransackers to add custom search functions via Arel
 
 The main premise behind Ransack is to provide access to

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ List of all possible predicates
 * `*_cont`, `*_cont_any`, `*_cont_all`, `*_not_cont`, `*_not_cont_any`, `*_not_cont_all` - contains value, using `LIKE`
 * `*_true`, `*_false` - is true and is false
 
-(See full list: https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/locale/en.yml#L15)
+(See full list: https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/locale/en.yml#L15 and [wiki](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching))
 
 ### Using Ransackers to add custom search functions via Arel
 


### PR DESCRIPTION
I often open this repo because I don't remember all predicates.
And for some predicates it was not obvious for me how to use it, so I had to search in repo.

I hope this section in README will be helpful for people like me, but probably need some help to make better description.

Also:
- `_eq_any` is same as `_in` ? (and `_not_eq_any` is same as `_not_in`?)
- What's the point to use `eq_all` ? If I use it as `col_eq: ["A", "B"]`, how something can be equal "A" and "B" at the same time?
- What's the point to use `gt_any`? If value in DB is greater then any then it's greater then smallest searchable value?
- Same with `gt_all` - if greater then all, then also greater then biggest
- If I do `start_all: ["A", "B"]`, anything can start with "A" and "B" at the same time?
