### PR TITLE
Fix returned value when several predicate.right

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -26,17 +26,23 @@ module Ransack
           arel_pred = arel_predicate_for_attribute(attribute)
           arel_values = formatted_values_for_attribute(attribute)
           predicate = attribute.attr.public_send(arel_pred, arel_values)
-          if casted_array_with_in_predicate?(predicate)
-            predicate.right[0] = format_values_for(predicate.right[0])
+
+          if in_predicate?(predicate)
+            predicate.right = predicate.right.map do |predicate|
+              casted_array?(predicate) ? format_values_for(predicate) : predicate
+            end
           end
+
           predicate
         end
 
-        def casted_array_with_in_predicate?(predicate)
+        def in_predicate?(predicate)
           return unless defined?(Arel::Nodes::Casted)
-          predicate.class == Arel::Nodes::In &&
-          predicate.right[0].respond_to?(:val) &&
-          predicate.right[0].val.is_a?(Array)
+          predicate.class == Arel::Nodes::In
+        end
+
+        def casted_array?(predicate)
+          predicate.respond_to?(:val) && predicate.val.is_a?(Array)
         end
 
         def format_values_for(predicate)

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -314,8 +314,8 @@ module Ransack
 
           context 'searching on an `in` predicate with a ransacker' do
             it 'should function correctly when passing an array of ids' do
-              s = Person.ransack(array_users_in: true)
-              expect(s.result.count).to be > 0
+              s = Person.ransack(array_users_in: [1, 2])
+              expect(s.result.count).to be 2
             end
 
             it 'should function correctly when passing an array of strings' do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -67,7 +67,7 @@ class Person < ActiveRecord::Base
   end
 
   ransacker :array_users,
-    formatter: proc { |v| Person.first(2).map(&:id) } do |parent|
+    formatter: proc { |v| Person.where(id: v).map(&:id) } do |parent|
     parent.table[:id]
   end
 


### PR DESCRIPTION
I tried to change `spec/support/schema.rb` and `spec/ransack/adapters/active_record/base_spec.rb` like below.

```rb
# spec/support/schema.rb:69
ransacker :array_users,                                                                                                
  formatter: proc { |v| Person.where(id: v).map(&:id) } do |parent|                                                    
  parent.table[:id]                                                                                                    
end   
```

```rb
# spec/ransack/adapters/active_record/base_spec.rb:316
it 'should function correctly when passing an array of ids' do                                                           
  s = Person.ransack(array_users_in: [1, 2])                                                                               
  expect(s.result.count).to be 2
end
```

Should be pass tests but that couldn't pass tests.

Because, `Ransack::Nodes::Condition#format_predicate` method can target `predicate.right[0]` **only**.
I think the method should target several `predicate.right`.