### PR TITLE
use `ActiveSupport.on_load` to hook into Active Record

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -7,13 +7,6 @@ Ransack::Adapters.object_mapper.require_constants
 module Ransack
   extend Configuration
   class UntraversableAssociationError < StandardError; end;
-
-  SUPPORTS_ATTRIBUTE_ALIAS =
-  begin
-    ActiveRecord::Base.respond_to?(:attribute_aliases)
-  rescue NameError
-    false
-  end
 end
 
 Ransack.configure do |config|

--- a/lib/ransack/adapters/active_record.rb
+++ b/lib/ransack/adapters/active_record.rb
@@ -1,5 +1,15 @@
 require 'ransack/adapters/active_record/base'
-ActiveRecord::Base.extend Ransack::Adapters::ActiveRecord::Base
+
+ActiveSupport.on_load(:active_record) do
+  extend Ransack::Adapters::ActiveRecord::Base
+
+  Ransack::SUPPORTS_ATTRIBUTE_ALIAS =
+  begin
+    ActiveRecord::Base.respond_to?(:attribute_aliases)
+  rescue NameError
+    false
+  end
+end
 
 require 'ransack/adapters/active_record/context'
 


### PR DESCRIPTION
For avoiding autoloading these constants too soon.
This affect the initialization of Active Record.
Ref: https://github.com/rails/rails/issues/23589#issuecomment-229247727