### PR TITLE
define `Ransack::SUPPORTS_ATTRIBUTE_ALIAS` to mongoid adapter

### DIFF
--- a/lib/ransack/adapters/mongoid.rb
+++ b/lib/ransack/adapters/mongoid.rb
@@ -11,3 +11,5 @@ when /^3\.2\./
 else
   require 'ransack/adapters/mongoid/context'
 end
+
+Ransack::SUPPORTS_ATTRIBUTE_ALIAS = false


### PR DESCRIPTION
In #719, the definition of `Ransack::SUPPORTS_ATTRIBUTE_ALIAS` has changed when
Active Record is loaded.

In the impact, `Ransack::SUPPORTS_ATTRIBUTE_ALIAS` in mongo adapter has become no longer be defined,
modify to defined in mongoid adapter.

Follow up to #719