### PR TITLE
Add customizable indicator arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 ## Unreleased
+
+### Added
+
+*   Add config option to customize up and down arrows used for direction indicators in the FormHelper. PR [#726](https://github.com/activerecord-hackery/ransack/pull/726)
+
+    *Garett Arrowood*
+
 ### Fixed
 
 *   Use class attributes properly so that inheritance is respected.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,18 @@ The sort link may be displayed without the order indicator arrow by passing
 <%= sort_link(@q, :name, hide_indicator: true) %>
 ```
 
-Alternatively, all sort links may be displayed without the order indicator arrow
-by adding this to an initializer file like `config/initializers/ransack.rb`:
+These indicator arrows may also be customized by setting them in an initializer file like `config/initializers/ransack.rb`:
+
+```ruby
+Ransack.configure do |c|
+  c.custom_arrows = {
+    up_arrow: '<i class="custom-up-arrow-icon"></i>',
+    down_arrow: 'U+02193'
+  }
+end
+```
+
+Alternatively, all sort links may be displayed without the order indicator arrows:
 
 ```ruby
 Ransack.configure do |c|

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -77,10 +77,10 @@ module Ransack
       self.options[:ignore_unknown_conditions] = boolean
     end
 
-    # Ransack's default arrows are html-code snippets found options at the
-    # top of this file. Arrows may be anything wrapped in quotation marks.
-    # Both arrows or a single arrow may be globally overridden in an
-    # initializer file like `config/initializers/ransack.rb` as follows:
+    # Ransack's default indicator arrows are html-code snippets. These
+    # arrows may be replaced by anything wrapped in quotation marks. Both
+    # or just one arrow may be globally overridden in an initializer file
+    # like `config/initializers/ransack.rb` as follows:
     #
     # Ransack.configure do |config|
     #   # Set the up_arrow as an icon, set the down arrow as unicode

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -9,7 +9,9 @@ module Ransack
     self.options = {
       :search_key => :q,
       :ignore_unknown_conditions => true,
-      :hide_sort_order_indicators => false
+      :hide_sort_order_indicators => false,
+      :up_arrow => '&#9660;'.freeze,
+      :down_arrow => '&#9650;'.freeze
     }
 
     def configure
@@ -73,6 +75,24 @@ module Ransack
     #
     def ignore_unknown_conditions=(boolean)
       self.options[:ignore_unknown_conditions] = boolean
+    end
+
+    # Ransack's default arrows are html-code snippets found options at the
+    # top of this file. Arrows may be anything wrapped in quotation marks.
+    # Both arrows or a single arrow may be globally overridden in an
+    # initializer file like `config/initializers/ransack.rb` as follows:
+    #
+    # Ransack.configure do |config|
+    #   # Set the up_arrow as an icon, set the down arrow as unicode
+    #   config.custom_arrows = {
+    #     up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+    #     down_arrow: 'U+02193'
+    #   }
+    # end
+    #
+    def custom_arrows=(opts = {})
+      self.options[:up_arrow] = opts[:up_arrow].freeze if opts[:up_arrow]
+      self.options[:down_arrow] = opts[:down_arrow].freeze if opts[:down_arrow]
     end
 
     # By default, Ransack displays sort order indicator arrows in sort links.

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -110,11 +110,11 @@ module Ransack
         end
 
         def up_arrow
-          '&#9660;'.freeze
+          Ransack.options[:up_arrow]
         end
 
         def down_arrow
-          '&#9650;'.freeze
+          Ransack.options[:down_arrow]
         end
 
         def name

--- a/spec/mongoid/configuration_spec.rb
+++ b/spec/mongoid/configuration_spec.rb
@@ -49,6 +49,29 @@ module Ransack
       Ransack.options = before
     end
 
+    it 'should have default values for arrows' do
+      expect(Ransack.options[:up_arrow]).to eq '&#9660;'.freeze
+      expect(Ransack.options[:down_arrow]).to eq '&#9650;'.freeze
+    end
+
+    it 'changes default arrow strings' do
+      # store original state so we can restore it later
+      before = Ransack.options.clone
+
+      Ransack.configure do |config|
+        config.custom_arrows = {
+          up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+          down_arrow: 'U+02193'
+        }
+      end
+
+      expect(Ransack.options[:up_arrow]).to eq '<i class="fa fa-long-arrow-up"></i>'.freeze
+      expect(Ransack.options[:down_arrow]).to eq 'U+02193'.freeze
+
+      # restore original state so we don't break other tests
+      Ransack.options = before
+    end
+
     it 'adds predicates that take arrays, overriding compounds' do
       Ransack.configure do |config|
         config.add_predicate(

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -51,6 +51,29 @@ module Ransack
       Ransack.options = before
     end
 
+    it 'should have default values for arrows' do
+      expect(Ransack.options[:up_arrow]).to eq '&#9660;'.freeze
+      expect(Ransack.options[:down_arrow]).to eq '&#9650;'.freeze
+    end
+
+    it 'changes default arrow strings' do
+      # store original state so we can restore it later
+      before = Ransack.options.clone
+
+      Ransack.configure do |config|
+        config.custom_arrows = {
+          up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+          down_arrow: 'U+02193'
+        }
+      end
+
+      expect(Ransack.options[:up_arrow]).to eq '<i class="fa fa-long-arrow-up"></i>'.freeze
+      expect(Ransack.options[:down_arrow]).to eq 'U+02193'.freeze
+
+      # restore original state so we don't break other tests
+      Ransack.options = before
+    end
+
     it 'adds predicates that take arrays, overriding compounds' do
       Ransack.configure do |config|
         config.add_predicate(

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -649,6 +649,52 @@ module Ransack
         it { should match /Full Name&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with config set with custom up_arrow' do
+        before do
+          Ransack.configure do |c|
+            c.custom_arrows = { up_arrow: "\u{1F446}" }
+          end
+        end
+        after do
+          #set back to default
+          Ransack.configure do |c|
+            c.custom_arrows = { up_arrow: "&#9660;" }
+          end
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people',
+            hide_indicator: false
+          )
+        }
+        it { should match /Full Name&nbsp;\u{1F446}/ }
+      end
+
+      describe '#sort_link with config set with custom down_arrow' do
+        before do
+          Ransack.configure do |c|
+            c.custom_arrows = { down_arrow: "\u{1F447}" }
+          end
+        end
+        after do
+          #set back to default
+          Ransack.configure do |c|
+            c.custom_arrows = { down_arrow: "&#9650;" }
+          end
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name asc'])],
+            :name,
+            controller: 'people',
+            hide_indicator: false
+          )
+        }
+        it { should match /Full Name&nbsp;\u{1F447}/ }
+      end
+
       describe '#sort_link with config set to globally hide order indicators' do
         before do
           Ransack.configure { |c| c.hide_sort_order_indicators = true }


### PR DESCRIPTION
This addition allows users to pass in their own up and down arrows. The default arrows remain the same. The user can pass in just one arrow, or both arrows.

Functionality is hand-tested with a codebase in production. Please let me know if you'd like any edits.