### PR TITLE
raise exception for unsupported adapters

### DIFF
--- a/lib/ransack/adapters.rb
+++ b/lib/ransack/adapters.rb
@@ -10,6 +10,8 @@ module Ransack
         ActiveRecordAdapter.new
       elsif defined?(::Mongoid)
         MongoidAdapter.new
+      else
+        raise "Unsupported adapter"
       end
     end
 


### PR DESCRIPTION
The reason can be found here: https://github.com/activeadmin/activeadmin/issues/4756
The solution is from @deivid-rodriguez in: https://github.com/activeadmin/activeadmin/issues/4756#issuecomment-275505455