### PR TITLE
Update README remove Rails 5 and pagination [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ branch:
 gem 'ransack', github: 'activerecord-hackery/ransack'
 ```
 
-If you are using Rails 5 or master and need pagination compatible with it and
-Ransack, there is a [Rails 5 version of the `will_paginate` gem here](https://github.com/jonatack/will_paginate).
-It is also optimized for Ruby 2.2+. To use it, in your Gemfile:
-`gem 'will_paginate', github: 'jonatack/will_paginate'`.
-
 ## Issues tracker
 
 * Before filing an issue, please read the [Contributing Guide](CONTRIBUTING.md).


### PR DESCRIPTION
The [will_paginate](https://github.com/mislav/will_paginate) has been updated for Rails 5 so I think this verbiage can be removed from the README. Thanks!