### PR TITLE
Evaluate ransackable_scopes before attributes when building the query

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -40,10 +40,10 @@ module Ransack
       collapse_multiparameter_attributes!(params).each do |key, value|
         if ['s'.freeze, 'sorts'.freeze].freeze.include?(key)
           send("#{key}=", value)
-        elsif base.attribute_method?(key)
-          base.send("#{key}=", value)
         elsif @context.ransackable_scope?(key, @context.object)
           add_scope(key, value)
+        elsif base.attribute_method?(key)
+          base.send("#{key}=", value)
         elsif !Ransack.options[:ignore_unknown_conditions]
           raise ArgumentError, "Invalid search term #{key}"
         end


### PR DESCRIPTION
[This paragraph](https://github.com/activerecord-hackery/ransack#using-scopesclass-methods) in README.md shows that Ransack can properly evaluate this scope: 
```ruby
 scope :salary_gt, ->(amount) { where('salary > ?', amount) }
```
if the scope is properly whitelisted:
```ruby
  def self.ransackable_scopes(auth_object = nil)
    %i(salary_gt)
  end
```
However, it is not the case because `attribute_method?(salary_gt)` will evaluate to `true` even if the attribute is not whitelisted in `ransackable/ransortable_attributes`.

I assumed that scopes were introduced to easily override/customize `#{attribute}_#{predicate}` pair without breaking the naming convention.
In that case this PR should make ransack work as per the README mentioned above.

Test cases will follow.
