### PR TITLE
[#138938207] Add scope support for ransortable_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 ## Unreleased
+
+### Added
+
+*   Add config option to customize up and down arrows used for direction indicators in the FormHelper. PR [#726](https://github.com/activerecord-hackery/ransack/pull/726)
+
+    *Garett Arrowood*
+
 ### Fixed
 
 *   Use class attributes properly so that inheritance is respected.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,18 @@ The sort link may be displayed without the order indicator arrow by passing
 <%= sort_link(@q, :name, hide_indicator: true) %>
 ```
 
-Alternatively, all sort links may be displayed without the order indicator arrow
-by adding this to an initializer file like `config/initializers/ransack.rb`:
+These indicator arrows may also be customized by setting them in an initializer file like `config/initializers/ransack.rb`:
+
+```ruby
+Ransack.configure do |c|
+  c.custom_arrows = {
+    up_arrow: '<i class="custom-up-arrow-icon"></i>',
+    down_arrow: 'U+02193'
+  }
+end
+```
+
+Alternatively, all sort links may be displayed without the order indicator arrows:
 
 ```ruby
 Ransack.configure do |c|

--- a/lib/ransack/adapters/active_record/3.0/context.rb
+++ b/lib/ransack/adapters/active_record/3.0/context.rb
@@ -27,10 +27,29 @@ module Ransack
         def evaluate(search, opts = {})
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
+
           if search.sorts.any?
             relation = relation.except(:order)
-            .reorder(viz.accept(search.sorts))
+            # Rather than applying all of the search's sorts in one fell swoop,
+            # as the original implementation does, we apply one at a time.
+            #
+            # If the sort (returned by the Visitor above) is a symbol, we know
+            # that it represents a scope on the model and we can apply that
+            # scope.
+            #
+            # Otherwise, we fall back to the applying the sort with the "order"
+            # method as the original implementation did. Actually the original
+            # implementation used "reorder," which was overkill since we already
+            # have a clean slate after "relation.except(:order)" above.
+            viz.accept(search.sorts).each do |scope_or_sort|
+              if scope_or_sort.is_a?(Symbol)
+                relation = relation.send(scope_or_sort)
+              else
+                relation = relation.order(scope_or_sort)
+              end
+            end
           end
+
           if opts[:distinct]
             relation.select(Constants::DISTINCT + @klass.quoted_table_name +
               Constants::DOT_ASTERIX)

--- a/lib/ransack/adapters/active_record/3.1/context.rb
+++ b/lib/ransack/adapters/active_record/3.1/context.rb
@@ -21,10 +21,29 @@ module Ransack
         def evaluate(search, opts = {})
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
+
           if search.sorts.any?
             relation = relation.except(:order)
-              .reorder(viz.accept(search.sorts))
+            # Rather than applying all of the search's sorts in one fell swoop,
+            # as the original implementation does, we apply one at a time.
+            #
+            # If the sort (returned by the Visitor above) is a symbol, we know
+            # that it represents a scope on the model and we can apply that
+            # scope.
+            #
+            # Otherwise, we fall back to the applying the sort with the "order"
+            # method as the original implementation did. Actually the original
+            # implementation used "reorder," which was overkill since we already
+            # have a clean slate after "relation.except(:order)" above.
+            viz.accept(search.sorts).each do |scope_or_sort|
+              if scope_or_sort.is_a?(Symbol)
+                relation = relation.send(scope_or_sort)
+              else
+                relation = relation.order(scope_or_sort)
+              end
+            end
           end
+
           if opts[:distinct]
             relation.select(Constants::DISTINCT + @klass.quoted_table_name +
               Constants::DOT_ASTERIX)

--- a/lib/ransack/adapters/active_record/3.2/context.rb
+++ b/lib/ransack/adapters/active_record/3.2/context.rb
@@ -32,9 +32,29 @@ module Ransack
         def evaluate(search, opts = {})
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
+
           if search.sorts.any?
-            relation = relation.except(:order).reorder(viz.accept(search.sorts))
+            relation = relation.except(:order)
+            # Rather than applying all of the search's sorts in one fell swoop,
+            # as the original implementation does, we apply one at a time.
+            #
+            # If the sort (returned by the Visitor above) is a symbol, we know
+            # that it represents a scope on the model and we can apply that
+            # scope.
+            #
+            # Otherwise, we fall back to the applying the sort with the "order"
+            # method as the original implementation did. Actually the original
+            # implementation used "reorder," which was overkill since we already
+            # have a clean slate after "relation.except(:order)" above.
+            viz.accept(search.sorts).each do |scope_or_sort|
+              if scope_or_sort.is_a?(Symbol)
+                relation = relation.send(scope_or_sort)
+              else
+                relation = relation.order(scope_or_sort)
+              end
+            end
           end
+
           opts[:distinct] ? relation.uniq : relation
         end
 

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -35,9 +35,29 @@ module Ransack
         def evaluate(search, opts = {})
           viz = Visitor.new
           relation = @object.where(viz.accept(search.base))
+
           if search.sorts.any?
-            relation = relation.except(:order).reorder(viz.accept(search.sorts))
+            relation = relation.except(:order)
+            # Rather than applying all of the search's sorts in one fell swoop,
+            # as the original implementation does, we apply one at a time.
+            #
+            # If the sort (returned by the Visitor above) is a symbol, we know
+            # that it represents a scope on the model and we can apply that
+            # scope.
+            #
+            # Otherwise, we fall back to the applying the sort with the "order"
+            # method as the original implementation did. Actually the original
+            # implementation used "reorder," which was overkill since we already
+            # have a clean slate after "relation.except(:order)" above.
+            viz.accept(search.sorts).each do |scope_or_sort|
+              if scope_or_sort.is_a?(Symbol)
+                relation = relation.send(scope_or_sort)
+              else
+                relation = relation.order(scope_or_sort)
+              end
+            end
           end
+
           opts[:distinct] ? relation.distinct : relation
         end
 

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -9,7 +9,9 @@ module Ransack
     self.options = {
       :search_key => :q,
       :ignore_unknown_conditions => true,
-      :hide_sort_order_indicators => false
+      :hide_sort_order_indicators => false,
+      :up_arrow => '&#9660;'.freeze,
+      :down_arrow => '&#9650;'.freeze
     }
 
     def configure
@@ -73,6 +75,24 @@ module Ransack
     #
     def ignore_unknown_conditions=(boolean)
       self.options[:ignore_unknown_conditions] = boolean
+    end
+
+    # Ransack's default indicator arrows are html-code snippets. These
+    # arrows may be replaced by anything wrapped in quotation marks. Both
+    # or just one arrow may be globally overridden in an initializer file
+    # like `config/initializers/ransack.rb` as follows:
+    #
+    # Ransack.configure do |config|
+    #   # Set the up_arrow as an icon, set the down arrow as unicode
+    #   config.custom_arrows = {
+    #     up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+    #     down_arrow: 'U+02193'
+    #   }
+    # end
+    #
+    def custom_arrows=(opts = {})
+      self.options[:up_arrow] = opts[:up_arrow].freeze if opts[:up_arrow]
+      self.options[:down_arrow] = opts[:down_arrow].freeze if opts[:down_arrow]
     end
 
     # By default, Ransack displays sort order indicator arrows in sort links.

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -110,11 +110,11 @@ module Ransack
         end
 
         def up_arrow
-          '&#9660;'.freeze
+          Ransack.options[:up_arrow]
         end
 
         def down_arrow
-          '&#9650;'.freeze
+          Ransack.options[:down_arrow]
         end
 
         def name

--- a/lib/ransack/visitor.rb
+++ b/lib/ransack/visitor.rb
@@ -41,7 +41,19 @@ module Ransack
     end
 
     def visit_Ransack_Nodes_Sort(object)
-      object.attr.send(object.dir) if object.valid?
+      # The first half of this conditional is the original implementation in
+      # Ransack, as of version 1.6.6.
+      #
+      # The second half of the conditional kicks in when the column name
+      # provided isn't found/valid. In those cases, we look for a scope on the
+      # model that will apply a custom sort. If found, we return the scope's
+      # name.
+      if object.valid?
+        object.attr.send(object.dir)
+      else
+        scope_name = :"sort_by_#{object.name}_#{object.dir}"
+        scope_name if object.context.object.respond_to?(scope_name)
+      end
     end
 
     def quoted?(object)

--- a/spec/mongoid/configuration_spec.rb
+++ b/spec/mongoid/configuration_spec.rb
@@ -49,6 +49,29 @@ module Ransack
       Ransack.options = before
     end
 
+    it 'should have default values for arrows' do
+      expect(Ransack.options[:up_arrow]).to eq '&#9660;'.freeze
+      expect(Ransack.options[:down_arrow]).to eq '&#9650;'.freeze
+    end
+
+    it 'changes default arrow strings' do
+      # store original state so we can restore it later
+      before = Ransack.options.clone
+
+      Ransack.configure do |config|
+        config.custom_arrows = {
+          up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+          down_arrow: 'U+02193'
+        }
+      end
+
+      expect(Ransack.options[:up_arrow]).to eq '<i class="fa fa-long-arrow-up"></i>'.freeze
+      expect(Ransack.options[:down_arrow]).to eq 'U+02193'.freeze
+
+      # restore original state so we don't break other tests
+      Ransack.options = before
+    end
+
     it 'adds predicates that take arrays, overriding compounds' do
       Ransack.configure do |config|
         config.add_predicate(

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -51,6 +51,29 @@ module Ransack
       Ransack.options = before
     end
 
+    it 'should have default values for arrows' do
+      expect(Ransack.options[:up_arrow]).to eq '&#9660;'.freeze
+      expect(Ransack.options[:down_arrow]).to eq '&#9650;'.freeze
+    end
+
+    it 'changes default arrow strings' do
+      # store original state so we can restore it later
+      before = Ransack.options.clone
+
+      Ransack.configure do |config|
+        config.custom_arrows = {
+          up_arrow: '<i class="fa fa-long-arrow-up"></i>',
+          down_arrow: 'U+02193'
+        }
+      end
+
+      expect(Ransack.options[:up_arrow]).to eq '<i class="fa fa-long-arrow-up"></i>'.freeze
+      expect(Ransack.options[:down_arrow]).to eq 'U+02193'.freeze
+
+      # restore original state so we don't break other tests
+      Ransack.options = before
+    end
+
     it 'adds predicates that take arrays, overriding compounds' do
       Ransack.configure do |config|
         config.add_predicate(

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -649,6 +649,52 @@ module Ransack
         it { should match /Full Name&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with config set with custom up_arrow' do
+        before do
+          Ransack.configure do |c|
+            c.custom_arrows = { up_arrow: "\u{1F446}" }
+          end
+        end
+        after do
+          #set back to default
+          Ransack.configure do |c|
+            c.custom_arrows = { up_arrow: "&#9660;" }
+          end
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name desc'])],
+            :name,
+            controller: 'people',
+            hide_indicator: false
+          )
+        }
+        it { should match /Full Name&nbsp;\u{1F446}/ }
+      end
+
+      describe '#sort_link with config set with custom down_arrow' do
+        before do
+          Ransack.configure do |c|
+            c.custom_arrows = { down_arrow: "\u{1F447}" }
+          end
+        end
+        after do
+          #set back to default
+          Ransack.configure do |c|
+            c.custom_arrows = { down_arrow: "&#9650;" }
+          end
+        end
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search(sorts: ['name asc'])],
+            :name,
+            controller: 'people',
+            hide_indicator: false
+          )
+        }
+        it { should match /Full Name&nbsp;\u{1F447}/ }
+      end
+
       describe '#sort_link with config set to globally hide order indicators' do
         before do
           Ransack.configure { |c| c.hide_sort_order_indicators = true }


### PR DESCRIPTION
Allows sorting logic to be applied through `ActiveRecord` scopes rather than just column names. Ransack already supports scoped filtering through `ransackable_scopes`, this PR provides a similar behavior for `ransortable_attributes` (see Ransack [README](https://github.com/activerecord-hackery/ransack#authorization-whitelistingblacklisting) for more information on these features).

### More Background and Use-cases

This change will allow for sorting on dynamically computed columns defined via scopes.

For example, given the `LoanApplication` model below defining some sorting scopes:

```ruby
class LoanApplication < ActiveRecord::Base
  # Sorts loan applications by the approval rate computed below
  scope :sort_by_approval_rate, ->(dir: "ASC") { order("(approved_amount / applied_amount) #{dir}") }
  scope :sort_by_approval_rate_asc, -> { sort_by_approval_rate }
  scope :sort_by_approval_rate_desc, -> { sort_by_approval_rate dir: "DESC" }

  class << self
    def ransortable_attributes(auth_object = nil)
      super(auth_object) + [
        :sort_by_approval_rate_asc,
        :sort_by_approval_rate_desc,
      ]
    end
  end
end
```

When using `Ransack` to search for loan applications with the criteria of `params[:q] = { s: "approval_rate asc" }`

```ruby
class LoanApplicationController  < ApplicationController
  def index
    @loan_applications = LoanApplication.ransack(params[:q]).result
  end
end
```

Ransack will verify that `approval_rate` is not a valid column on the `loan_applications` table, and will then check if the model defines sorting scopes for `approval_rate` and use them instead.

### Naming sorting scopes:

Sorting scopes are named as `sort_by_#{scope_name}_#{sorting_direction}`, where `scope_name` in the example above is `approval_rate` and `sorting_direction` is `asc` (define as the `s` attribute in the query `q` from `params`.

### Credits

This solution was borrowed from [this gist](https://gist.github.com/laserlemon/e5ce4e0d8bac63f4aa6835605ce3ec21).