### PR TITLE
Fix left_outer_joins not being respected

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -250,7 +250,10 @@ module Ransack
         # Checkout active_record/relation/query_methods.rb +build_joins+ for
         # reference. Lots of duplicated code maybe we can avoid it
         def build_joins(relation)
-          buckets = relation.joins_values.group_by do |join|
+          buckets = relation.joins_values
+          buckets += relation.left_outer_joins_values if ::ActiveRecord::VERSION::MAJOR >= 5
+
+          buckets = buckets.group_by do |join|
             case join
             when String
               :string_join


### PR DESCRIPTION
Given a relation that has `#left_outer_joins` before calling `#search`,

```
Person.left_outer_joins(:article).search(article_name_cont: 'foo')
```

Ransack will perform a `LEFT OUTER JOIN` twice resulting into an invalid query.

Since Rails 5.x.x added a `left_outer_joins_values`, `Context#build` must take
the existing joins from there too before automagically adding them.

This mimics the behavior added at
https://github.com/rails/rails/blob/ef7b9b867b3c113bbbc7639b5d760a8f962a683c/activerecord/lib/active_record/relation/query_methods.rb#L943

@seanfcarroll @jonatack 