### PR TITLE
Consider ransack aliases when sorting

### DIFF
--- a/lib/ransack/nodes/sort.rb
+++ b/lib/ransack/nodes/sort.rb
@@ -30,9 +30,9 @@ module Ransack
         .include?(attr_name)
       end
 
-      def name=(name)
-        @name = name
-        context.bind(self, name)
+      def name=name
+        @name = context.ransackable_alias(name) || name
+        context.bind(self, @name)
       end
 
       def dir=(dir)


### PR DESCRIPTION
`ransack_alias` is a great feature however it does not work with sorting out of the box. In my opinion `ransack_aliases` should be recognized by sort function out of the box. 

Consider the following example:
```ruby
class Post < ActiveRecord::Base
  belongs_to :author

  # Abbreviate :author_first_name_or_author_last_name to :author
  ransack_alias :author, :author_last_name
end
```
 In your view:
```
  <%= sort_link(@q, :author, 'Author Name') %>
```