### PR TITLE
get column type from ActiveRecord::Base#columns

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -29,7 +29,7 @@ module Ransack
           unless schema_cache.send(database_table_exists?, table)
             raise "No table named #{table} exists."
           end
-          schema_cache.columns_hash(table)[name].type
+          attr.klass.columns.find { |column| column.name == name }.type
         end
 
         def evaluate(search, opts = {})


### PR DESCRIPTION
I have run in to a small problem - in my project I have changed the definition of ActiveRecord::Base#columns to include virtual columns (computed columns). 
Example: if I have a User model with first_name and last_name, I create a virtual column full_name, which is concatenated first and last names. SQL looks like this:
```SQL
SELECT users.* FROM (SELECT *, (first_name || ' ' || last_name) AS full_name) AS users
```
This allows me to use full_name in WHERE, GROUP, ORDER BY clauses. After adding this column to ActiveRecord::Base#columns, #ransack method stops dropping "full_name_#{predicate}" keys from the params hash. But because later on it derives column type from schema_cache (which gets columns from the database), undefined method 'type' for nil is thrown.
Changing this to get columns from AR::Base#columns fixes the issue. This should be backwards compatible - AR::Base#columns also gets them from schema_cache.
