### PR TITLE
Add support to baby_squeel gem

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -260,6 +260,8 @@ module Ransack
               :stashed_join
             when Arel::Nodes::Join
               :join_node
+            when BabySqueel::JoinExpression
+              :joining
             else
               raise 'unknown class: %s' % join.class.name
             end


### PR DESCRIPTION
Fixes Ransack::Adapters::ActiveRecord::Context class, to add support to baby_squeel gem.