### PR TITLE
Add an optional default arrow for unsorted fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,18 @@ initially sorting the `last_name` field by ascending order, and the
 
 The sort link order indicator arrows may be globally customized by setting a
 `custom_arrows` option in an initializer file like
-`config/initializers/ransack.rb`:
+`config/initializers/ransack.rb`.
+
+You can also enable a `default_arrow` which is displayed on all sortable fields
+which are not currently used in the sorting. This is disabled by default so
+nothing will be displayed:
 
 ```ruby
 Ransack.configure do |c|
   c.custom_arrows = {
     up_arrow: '<i class="custom-up-arrow-icon"></i>',
-    down_arrow: 'U+02193'
+    down_arrow: 'U+02193',
+    default_arrow: '<i class="default-arrow-icon"></i>'
   }
 end
 ```

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -12,6 +12,7 @@ module Ransack
       :hide_sort_order_indicators => false,
       :up_arrow => '&#9660;'.freeze,
       :down_arrow => '&#9650;'.freeze,
+      :default_arrow => nil,
       :sanitize_scope_args => true
     }
 
@@ -83,20 +84,25 @@ module Ransack
     #   up_arrow:   '&#9660;'
     #   down_arrow: '&#9650;'
     #
-    # One or both defaults may be globally overridden in an initializer file
+    # There is also a default arrow which is displayed if a column is not sorted.
+    # By default this is nil so nothing will be displayed.
+    #
+    # Any of the defaults may be globally overridden in an initializer file
     # like `config/initializers/ransack.rb` as follows:
     #
     # Ransack.configure do |config|
-    #   # Globally set the up arrow to an icon and the down arrow to unicode.
+    #   # Globally set the up arrow to an icon, and the down and default arrows to unicode.
     #   config.custom_arrows = {
     #     up_arrow:   '<i class="fa fa-long-arrow-up"></i>',
-    #     down_arrow: 'U+02193'
+    #     down_arrow: 'U+02193',
+    #     default_arrow: 'U+11047'
     #   }
     # end
     #
     def custom_arrows=(opts = {})
       self.options[:up_arrow] = opts[:up_arrow].freeze if opts[:up_arrow]
       self.options[:down_arrow] = opts[:down_arrow].freeze if opts[:down_arrow]
+      self.options[:default_arrow] = opts[:default_arrow].freeze if opts[:default_arrow]
     end
 
     # Ransack sanitizes many values in your custom scopes into booleans.

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -117,6 +117,10 @@ module Ransack
           Ransack.options[:down_arrow]
         end
 
+        def default_arrow
+          Ransack.options[:default_arrow]
+        end
+
         def name
           [ERB::Util.h(@label_text), order_indicator]
           .compact
@@ -209,7 +213,8 @@ module Ransack
           end
 
           def order_indicator
-            return if @hide_indicator || no_sort_direction_specified?
+            return if @hide_indicator
+            return default_arrow if no_sort_direction_specified?
             if @current_dir == 'desc'.freeze
               up_arrow
             else

--- a/spec/ransack/configuration_spec.rb
+++ b/spec/ransack/configuration_spec.rb
@@ -48,6 +48,7 @@ module Ransack
     it 'should have default values for arrows' do
       expect(Ransack.options[:up_arrow]).to eq '&#9660;'
       expect(Ransack.options[:down_arrow]).to eq '&#9650;'
+      expect(Ransack.options[:default_arrow]).to eq nil
     end
 
     it 'changes the default value for the up arrow only' do
@@ -72,17 +73,31 @@ module Ransack
       Ransack.options = default
     end
 
-    it 'changes the default value for both arrows' do
+    it 'changes the default value for the default arrow only' do
+      default, new_default_arrow  = Ransack.options.clone, '<i class="default"></i>'
+
+      Ransack.configure { |c| c.custom_arrows = { default_arrow: new_default_arrow } }
+
+      expect(Ransack.options[:up_arrow]).to eq default[:up_arrow]
+      expect(Ransack.options[:down_arrow]).to eq default[:down_arrow]
+      expect(Ransack.options[:default_arrow]).to eq new_default_arrow
+
+      Ransack.options = default
+    end
+
+    it 'changes the default value for all arrows' do
       default        = Ransack.options.clone
       new_up_arrow   = '<i class="fa fa-long-arrow-up"></i>'
       new_down_arrow = 'U+02193'
+      new_default_arrow = 'defaultarrow'
 
       Ransack.configure do |c|
-        c.custom_arrows = { up_arrow: new_up_arrow, down_arrow: new_down_arrow }
+        c.custom_arrows = { up_arrow: new_up_arrow, down_arrow: new_down_arrow, default_arrow: new_default_arrow }
       end
 
       expect(Ransack.options[:up_arrow]).to eq new_up_arrow
       expect(Ransack.options[:down_arrow]).to eq new_down_arrow
+      expect(Ransack.options[:default_arrow]).to eq new_default_arrow
 
       Ransack.options = default
     end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -727,11 +727,36 @@ module Ransack
         it { should match /Full Name&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with config set to show arrows and a default arrow set' do
+        before do
+          Ransack.configure do |c|
+            c.hide_sort_order_indicators = false
+            c.custom_arrows = { default_arrow: "defaultarrow"}
+          end
+        end
+
+        after do
+          Ransack.configure do |c|
+            c.custom_arrows = { default_arrow: nil}
+          end
+        end
+
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.search],
+            :name,
+            controller: 'people'
+          )
+        }
+
+        it { should match /Full Name&nbsp;defaultarrow/ }
+      end
+
       describe '#sort_link w/config to hide arrows + custom arrow, hides all' do
         before do
           Ransack.configure do |c|
             c.hide_sort_order_indicators = true
-            c.custom_arrows = { down_arrow: 'down' }
+            c.custom_arrows = { down_arrow: 'down', default_arrow: "defaultarrow" }
           end
         end
 
@@ -750,7 +775,7 @@ module Ransack
           )
         }
 
-        it { should_not match /&#9660;|down/ }
+        it { should_not match /&#9660;|down|defaultarrow/ }
       end
 
       describe '#sort_link with config set to show arrows + custom arrow' do


### PR DESCRIPTION
Currently if a field is not sorted then no icon is displayed. By default this behaviour will stay the same, however there is now the option of setting a `default_arrow` in the configuration which would be displayed on all sortable columns currently not sorted.

I could not find a sensible unicode character to do this, however bootstrap glyphicons / font awesome both have good options for it (`fa-sort` for example).

The default value of `default_arrow` is `nil` which keeps the current API exactly the same unless this configuration is changed.