### PR TITLE
Bug: negative condition with a default scope

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -184,7 +184,7 @@ module Ransack
           join_table = join_root.left
           correlated_key = join_root.right.expr.left
           subquery = Arel::SelectManager.new(association.base_klass)
-          subquery.from(join_root.left)
+          subquery.from(join_table)
           subquery.project(correlated_key)
           join_constraints.each do |j|
             subquery.join_sources << Arel::Nodes::InnerJoin.new(j.left, j.right)

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -102,6 +102,15 @@ module Ransack
           end
         end
 
+        context 'negative condition where the joined association has a default scope' do
+          it 'applies the default scope' do
+            # Article has default_scope
+            s = Person.ransack(articles_title_not_eq: 'Breaking news')
+            sql = s.result.to_sql
+            expect(sql).to include "WHERE ('default_scope' = 'default_scope')"
+          end
+        end
+
         context 'negative conditions on HABTM associations' do
           let(:medieval) { Tag.create!(name: 'Medieval') }
           let(:fantasy)  { Tag.create!(name: 'Fantasy') }

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -849,6 +849,11 @@ module Ransack
         before do
           Ransack.configure { |c| c.search_key = :example }
         end
+
+        after do
+          Ransack.configure { |c| c.search_key = :q }
+        end
+
         subject {
           @controller.view_context
           .search_form_for(Person.search) { |f| f.text_field :name_eq }

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -157,12 +157,6 @@ module Namespace
   end
 end
 
-module Namespace
-  class Article < ::Article
-
-  end
-end
-
 class Comment < ActiveRecord::Base
   belongs_to :article
   belongs_to :person


### PR DESCRIPTION
Not a full-fledged PR, but a starting point for fixing a bug that occurs when `default_scope` is present on the joined association (see the regression spec below).

![screen shot 2017-11-01 at 12 50 03 pm](https://user-images.githubusercontent.com/7811733/32261752-4202637a-bf03-11e7-9653-9dfc1048e66d.png)

I am not overly familiar with `ransack`'s internals, so I was hoping you guys would know how to handle this case. @avit you did some nice work on https://github.com/activerecord-hackery/ransack/commit/96d0fd75ade6a6ca019ccc03cca6d876f0e12ecf and this is directly related to your changes, so I was wondering if you have a fix in mind?