### PR TITLE
Use lazy load hooks to hook on ActionController::Base

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -26,4 +26,6 @@ require 'ransack/translate'
 
 Ransack::Adapters.object_mapper.require_adapter
 
-ActionController::Base.helper Ransack::Helpers::FormHelper
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Base.helper Ransack::Helpers::FormHelper
+end


### PR DESCRIPTION
Hello guys thanks for creating and maintaining this gem 😍 

Use lazy load hooks to hook on ActionController::Base:

- Calling directly `ActionController::Base` affects the initialization process (one of them being one that controls ActionController [configuration](https://github.com/rails/rails/blob/aa6bcbbac8517d5b077f21073e9902637d7c7157/actionpack/lib/action_controller/railtie.rb#L53-L67))
- As a result setting configuration inside an initializer (such as the asset_host), won't have any effect