### PR TITLE
Fix custom search with scope

### DIFF
--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -46,7 +46,11 @@ module Ransack
 
     def chain_scope(scope, args)
       return unless @klass.method(scope)
-      @object = @object.public_send(scope, *args)
+      @object = if scope_arity(scope) < 1 && args == true
+                  @object.public_send(scope)
+                else
+                  @object.public_send(scope, *args)
+                end
     end
 
     def scope_arity(scope)

--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -45,12 +45,8 @@ module Ransack
     end
 
     def chain_scope(scope, args)
-      return unless @klass.method(scope) && args != false
-      @object = if scope_arity(scope) < 1 && args == true
-                  @object.public_send(scope)
-                else
-                  @object.public_send(scope, *args)
-                end
+      return unless @klass.method(scope)
+      @object = @object.public_send(scope, *args)
     end
 
     def scope_arity(scope)


### PR DESCRIPTION
Example:
```ruby
class Shoot::Video < ApplicationRecord
  acts_as_paranoid

  scope :choiced, -> (boolean = true) {
    if boolean
      where.not(choiced_at: nil)
    else
      where(choiced_at: nil)
    end
  }

  def self.ransackable_scopes(auth_object = nil)
    %i(choiced)
  end
end
```
when false be passed as boolean to scope, here is no scope search.
```ruby
Shoot::Video.ransack(choiced: 'false', s: 'hot desc').result.to_sql
# SELECT `shoot_videos`.* FROM `shoot_videos` WHERE `shoot_videos`.`deleted_at` IS NULL ORDER BY `shoot_videos`.`hot` DESC
```