### PR TITLE
Let escape_wildcards not escape '|'

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/constants.rb
+++ b/lib/ransack/adapters/active_record/ransack/constants.rb
@@ -104,7 +104,7 @@ module Ransack
       case ActiveRecord::Base.connection.adapter_name
       when "Mysql2".freeze, "PostgreSQL".freeze
         # Necessary for PostgreSQL and MySQL
-        unescaped.to_s.gsub(/([\\|\%|_|.])/, '\\\\\\1')
+        unescaped.to_s.gsub(/([\\%_.])/, '\\\\\\1')
       else
         unescaped
       end


### PR DESCRIPTION
The regexp `/([\\|\%|_|.])/` means `\` or `|` or `%` or `|` or `_` or `|` or `.`, which includes unwanted `|` character multiple times.