### PR TITLE
Fix build_joins on Rails 5.2.rc1

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -290,7 +290,7 @@ module Ransack
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(::ActiveRecord::Base.connection, relation.table.name, join_list)
             join_dependency = JoinDependency.new(relation.klass, relation.table, association_joins, alias_tracker)
             join_nodes.each do |join|
-              join_dependency.alias_tracker.aliases[join.left.name.downcase] = 1
+              join_dependency.send(:alias_tracker).aliases[join.left.name.downcase] = 1
             end
           end
 


### PR DESCRIPTION
Fixes the following error:

    protected method `alias_tracker' called for #<ActiveRecord::Associations::JoinDependency:0x0000000002fc3bc0>

The method is still protected in Rails 5.2 and so must be called via `send`.