### PR TITLE
fix accessing alias tracker in activerecord context

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -290,7 +290,7 @@ module Ransack
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(::ActiveRecord::Base.connection, relation.table.name, join_list)
             join_dependency = JoinDependency.new(relation.klass, relation.table, association_joins, alias_tracker)
             join_nodes.each do |join|
-              join_dependency.alias_tracker.aliases[join.left.name.downcase] = 1
+              join_dependency.send(:alias_tracker).aliases[join.left.name.downcase] = 1
             end
           end
 


### PR DESCRIPTION
I'm getting error while trying to access it
```
NoMethodError:
  protected method `alias_tracker' called for #<ActiveRecord::Associations::JoinDependency:0x00007ff94a973a88>
/home/ubuntu/spree/vendor/bundle/ruby/2.4.0/gems/ransack-1.8.7/lib/ransack/adapters/active_record/context.rb:293:in `block in build_joins'
```