### PR TITLE
Refactor inject

### DIFF
--- a/lib/ransack/adapters/active_record/3.0/compat.rb
+++ b/lib/ransack/adapters/active_record/3.0/compat.rb
@@ -3,13 +3,7 @@ if Arel::Nodes::And < Arel::Nodes::Binary
   class Ransack::Visitor
     def visit_Ransack_Nodes_And(object)
       nodes = object.values.map { |o| accept(o) }.compact
-      return nil unless nodes.size > 0
-
-      if nodes.size > 1
-        nodes.inject(&:and)
-      else
-        nodes.first
-      end
+      nodes.inject(&:and)
     end
   end
 end

--- a/lib/ransack/adapters/mongoid/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/mongoid/ransack/nodes/condition.rb
@@ -10,15 +10,10 @@ module Ransack
           )
         end
 
-        if predicates.size > 1
-          case combinator
-          when 'and'
-            Arel::Nodes::Grouping.new(Arel::Nodes::And.new(predicates))
-          when 'or'
-            predicates.inject(&:or)
-          end
+        if predicates.size > 1 && combinator == 'and'
+          Arel::Nodes::Grouping.new(Arel::Nodes::And.new(predicates))
         else
-          predicates.first
+          predicates.inject(&:or)
         end
       end
 

--- a/lib/ransack/adapters/mongoid/ransack/visitor.rb
+++ b/lib/ransack/adapters/mongoid/ransack/visitor.rb
@@ -2,13 +2,7 @@ module Ransack
   class Visitor
     def visit_and(object)
       nodes = object.values.map { |o| accept(o) }.compact
-      return nil unless nodes.size > 0
-
-      if nodes.size > 1
-        nodes.inject(&:and)
-      else
-        nodes.first
-      end
+      nodes.inject(&:and)
     end
 
     def quoted?(object)

--- a/lib/ransack/visitor.rb
+++ b/lib/ransack/visitor.rb
@@ -31,13 +31,7 @@ module Ransack
 
     def visit_or(object)
       nodes = object.values.map { |o| accept(o) }.compact
-      return nil unless nodes.size > 0
-
-      if nodes.size > 1
-        nodes.inject(&:or)
-      else
-        nodes.first
-      end
+      nodes.inject(&:or)
     end
 
     def quoted?(object)


### PR DESCRIPTION
I noticed a few places with the pattern:

```ruby
return nil unless nodes.size > 0

if nodes.size > 1
  nodes.inject(&:and)
else
  nodes.first
end
```

This can be simplfied to just:

```ruby
nodes.inject(&:and)
```

since `inject` returns the first element if the array only has one element, and `nil` if the array has no elements (which is exactly what the more verbose code is doing).