### PR TITLE
Fixes broken monkey patch of #form_with

### DIFF
--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -13,7 +13,11 @@ module ActionView::Helpers::Tags
         end
       else # rails/rails#29791
         def value
-          @object.send @method_name if @object
+          if @allow_method_names_outside_object
+            object.send @method_name if object && object.respond_to?(@method_name, true)
+          else
+            object.send @method_name if object
+          end
         end
       end
     end


### PR DESCRIPTION
In rails 5.1, 5.2 provides `#form_with` method for view.
Unfortunately, ransack's monkey patch breaks behavior of it.

The documented code doesn't work because current ransack's monkey patch is broken.

```
http://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormHelper.html#method-i-form_with
form_with model: Cat.new do |form|
  form.text_field :cats_dont_have_gills
  form.text_field :but_in_forms_they_can
end
```