### PR TITLE
Docs: Note limitation of the *_present predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ List of all possible predicates
 | `*_lteq` | less than or equal | |
 | `*_gt` | greater than | |
 | `*_gteq` | greater than or equal | |
-| `*_present` | not null and not empty | e.g. `q[name_present]=1` (SQL: `col is not null AND col != ''`) |
+| `*_present` | not null and not empty | Only compatible with string columns. Example: `q[name_present]=1` (SQL: `col is not null AND col != ''`) |
 | `*_blank` | is null or empty. | (SQL: `col is null OR col = ''`) |
 | `*_null` | is null | |
 | `*_not_null` | is not null | |


### PR DESCRIPTION
Per https://github.com/activerecord-hackery/ransack/issues/641, `*_present` is only compatible with string-like columns.