### PR TITLE
Test against Rails 5.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
   - RAILS=5-2-stable DB=mysql
   - RAILS=5-2-stable DB=postgres
 
-  - RAILS=v5.2.1.rc1 DB=sqlite3
-  - RAILS=v5.2.1.rc1 DB=mysql
-  - RAILS=v5.2.1.rc1 DB=postgres
+  - RAILS=v5.2.1 DB=sqlite3
+  - RAILS=v5.2.1 DB=mysql
+  - RAILS=v5.2.1 DB=postgres
 
   - RAILS=v5.2.0 DB=sqlite3
   - RAILS=v5.2.0 DB=mysql


### PR DESCRIPTION
Ref: https://weblog.rubyonrails.org/2018/8/7/Rails-5-2-1-has-been-released/