### PR TITLE
Remove internal methods which are no longer used

### DIFF
--- a/lib/polyamorous/activerecord_5.1_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_5.1_ruby_2/join_association.rb
@@ -20,13 +20,6 @@ module Polyamorous
       end
     end
 
-    # Reference: https://github.com/rails/rails/commit/9b15db5
-    # NOTE: Not sure we still need it?
-    #
-    def ==(other)
-      base_klass == other.base_klass
-    end
-
     def build_constraint(klass, table, key, foreign_table, foreign_key)
       if reflection.polymorphic?
         super(klass, table, key, foreign_table, foreign_key)

--- a/lib/polyamorous/activerecord_5.1_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.1_ruby_2/join_dependency.rb
@@ -30,24 +30,6 @@ module Polyamorous
       end
     end
 
-    def find_join_association_respecting_polymorphism(reflection, parent, klass)
-      if association = parent.children.find { |j| j.reflection == reflection }
-        unless reflection.polymorphic?
-          association
-        else
-          association if association.base_klass == klass
-        end
-      end
-    end
-
-    def build_join_association_respecting_polymorphism(reflection, parent, klass)
-      if reflection.polymorphic? && klass
-        JoinAssociation.new(reflection, self, klass)
-      else
-        JoinAssociation.new(reflection, self)
-      end
-    end
-
     # Replaces ActiveRecord::Associations::JoinDependency#join_constraints
     #
     # This internal method was changed in Rails 5.0 by commit

--- a/lib/polyamorous/activerecord_5.2.0_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_5.2.0_ruby_2/join_association.rb
@@ -20,13 +20,6 @@ module Polyamorous
       end
     end
 
-    # Reference: https://github.com/rails/rails/commit/9b15db5
-    # NOTE: Not sure we still need it?
-    #
-    def ==(other)
-      base_klass == other.base_klass
-    end
-
     def build_constraint(klass, table, key, foreign_table, foreign_key)
       if reflection.polymorphic?
         super(klass, table, key, foreign_table, foreign_key)

--- a/lib/polyamorous/activerecord_5.2.0_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.2.0_ruby_2/join_dependency.rb
@@ -30,24 +30,6 @@ module Polyamorous
       end
     end
 
-    def find_join_association_respecting_polymorphism(reflection, parent, klass)
-      if association = parent.children.find { |j| j.reflection == reflection }
-        unless reflection.polymorphic?
-          association
-        else
-          association if association.base_klass == klass
-        end
-      end
-    end
-
-    def build_join_association_respecting_polymorphism(reflection, parent, klass)
-      if reflection.polymorphic? && klass
-        JoinAssociation.new(reflection, self, alias_tracker, klass)
-      else
-        JoinAssociation.new(reflection, self, alias_tracker)
-      end
-    end
-
     # Replaces ActiveRecord::Associations::JoinDependency#join_constraints
     #
     # This internal method was changed in Rails 5.0 by commit

--- a/lib/polyamorous/activerecord_5.2.1_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_5.2.1_ruby_2/join_association.rb
@@ -19,13 +19,6 @@ module Polyamorous
       end
     end
 
-    # Reference: https://github.com/rails/rails/commit/9b15db5
-    # NOTE: Not sure we still need it?
-    #
-    def ==(other)
-      base_klass == other.base_klass
-    end
-
     def build_constraint(klass, table, key, foreign_table, foreign_key)
       if reflection.polymorphic?
         super(klass, table, key, foreign_table, foreign_key)

--- a/lib/polyamorous/activerecord_5.2.1_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.2.1_ruby_2/join_dependency.rb
@@ -30,24 +30,6 @@ module Polyamorous
       end
     end
 
-    def find_join_association_respecting_polymorphism(reflection, parent, klass)
-      if association = parent.children.find { |j| j.reflection == reflection }
-        unless reflection.polymorphic?
-          association
-        else
-          association if association.base_klass == klass
-        end
-      end
-    end
-
-    def build_join_association_respecting_polymorphism(reflection, parent, klass)
-      if reflection.polymorphic? && klass
-        JoinAssociation.new(reflection, self, klass)
-      else
-        JoinAssociation.new(reflection, self)
-      end
-    end
-
     module ClassMethods
       # Prepended before ActiveRecord::Associations::JoinDependency#walk_tree
       #

--- a/spec/ransack/join_association_spec.rb
+++ b/spec/ransack/join_association_spec.rb
@@ -3,13 +3,11 @@ require 'spec_helper'
 module Polyamorous
   describe JoinAssociation do
 
-    join_base, join_association_args, polymorphic = :join_root, 'parent.children', 'reflection.options[:polymorphic]'
-
     let(:join_dependency) { new_join_dependency Note, {} }
     let(:reflection) { Note.reflect_on_association(:notable) }
-    let(:parent) { join_dependency.send(join_base) }
+    let(:parent) { join_dependency.send(:join_root) }
     let(:join_association) {
-      eval("new_join_association(reflection, #{join_association_args}, Article)")
+      new_join_association(reflection, parent.children, Article)
     }
 
     it 'leaves the orginal reflection intact for thread safety' do
@@ -24,7 +22,7 @@ module Polyamorous
     end
 
     it 'sets the polymorphic option to true after initializing' do
-      expect(join_association.instance_eval(polymorphic)).to be true
+      expect(join_association.reflection.options[:polymorphic]).to be true
     end
   end
 end

--- a/spec/ransack/join_association_spec.rb
+++ b/spec/ransack/join_association_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Polyamorous
   describe JoinAssociation do
 
-    join_base, join_association_args, polymorphic = [:join_root, 'parent.children', 'reflection.options[:polymorphic]']
+    join_base, join_association_args, polymorphic = :join_root, 'parent.children', 'reflection.options[:polymorphic]'
 
     let(:join_dependency) { new_join_dependency Note, {} }
     let(:reflection) { Note.reflect_on_association(:notable) }
@@ -11,25 +11,6 @@ module Polyamorous
     let(:join_association) {
       eval("new_join_association(reflection, #{join_association_args}, Article)")
     }
-
-    subject {
-      join_dependency.build_join_association_respecting_polymorphism(
-        reflection, parent, Person
-      )
-    }
-
-    it 'respects polymorphism on equality test' do
-      expect(subject).to eq(
-        join_dependency.build_join_association_respecting_polymorphism(
-          reflection, parent, Person
-        )
-      )
-      expect(subject).not_to eq(
-        join_dependency.build_join_association_respecting_polymorphism(
-          reflection, parent, Article
-        )
-      )
-    end
 
     it 'leaves the orginal reflection intact for thread safety' do
       reflection.instance_variable_set(:@klass, Article)

--- a/spec/ransack/join_dependency_spec.rb
+++ b/spec/ransack/join_dependency_spec.rb
@@ -3,32 +3,30 @@ require 'spec_helper'
 module Polyamorous
   describe JoinDependency do
 
-    method, join_associations = :instance_eval, 'join_root.drop(1)'
-
     context 'with symbol joins' do
       subject { new_join_dependency Person, articles: :comments }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq(2) }
-      specify { expect(subject.send(method, join_associations).map(&:join_type))
+      specify { expect(subject.send(:join_root).drop(1).map(&:join_type))
         .to be_all { Polyamorous::InnerJoin } }
     end
 
     context 'with has_many :through association' do
       subject { new_join_dependency Person, :authored_article_comments }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq 1 }
-      specify { expect(subject.send(method, join_associations).first.table_name)
+      specify { expect(subject.send(:join_root).drop(1).first.table_name)
         .to eq 'comments' }
     end
 
     context 'with outer join' do
       subject { new_join_dependency Person, new_join(:articles, :outer) }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq 1 }
-      specify { expect(subject.send(method, join_associations).first.join_type)
+      specify { expect(subject.send(:join_root).drop(1).first.join_type)
         .to eq Polyamorous::OuterJoin }
     end
 
@@ -36,22 +34,22 @@ module Polyamorous
       subject { new_join_dependency Person,
         new_join(:articles, :outer) => new_join(:comments, :outer) }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq 2 }
-      specify { expect(subject.send(method, join_associations).map(&:join_type))
+      specify { expect(subject.send(:join_root).drop(1).map(&:join_type))
         .to eq [Polyamorous::OuterJoin, Polyamorous::OuterJoin] }
-      specify { expect(subject.send(method, join_associations).map(&:join_type))
+      specify { expect(subject.send(:join_root).drop(1).map(&:join_type))
         .to be_all { Polyamorous::OuterJoin } }
     end
 
     context 'with polymorphic belongs_to join' do
       subject { new_join_dependency Note, new_join(:notable, :inner, Person) }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq 1 }
-      specify { expect(subject.send(method, join_associations).first.join_type)
+      specify { expect(subject.send(:join_root).drop(1).first.join_type)
         .to eq Polyamorous::InnerJoin }
-      specify { expect(subject.send(method, join_associations).first.table_name)
+      specify { expect(subject.send(:join_root).drop(1).first.table_name)
         .to eq 'people' }
     end
 
@@ -59,13 +57,13 @@ module Polyamorous
       subject { new_join_dependency Note,
         new_join(:notable, :inner, Person) => :comments }
 
-      specify { expect(subject.send(method, join_associations).size)
+      specify { expect(subject.send(:join_root).drop(1).size)
         .to eq 2 }
-      specify { expect(subject.send(method, join_associations).map(&:join_type))
+      specify { expect(subject.send(:join_root).drop(1).map(&:join_type))
         .to be_all { Polyamorous::InnerJoin } }
-      specify { expect(subject.send(method, join_associations).first.table_name)
+      specify { expect(subject.send(:join_root).drop(1).first.table_name)
         .to eq 'people' }
-      specify { expect(subject.send(method, join_associations)[1].table_name)
+      specify { expect(subject.send(:join_root).drop(1)[1].table_name)
         .to eq 'comments' }
     end
 

--- a/spec/ransack/join_dependency_spec.rb
+++ b/spec/ransack/join_dependency_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Polyamorous
   describe JoinDependency do
 
-    method, join_associations, join_base = :instance_eval, 'join_root.drop(1)', :join_root
+    method, join_associations = :instance_eval, 'join_root.drop(1)'
 
     context 'with symbol joins' do
       subject { new_join_dependency Person, articles: :comments }
@@ -53,15 +53,6 @@ module Polyamorous
         .to eq Polyamorous::InnerJoin }
       specify { expect(subject.send(method, join_associations).first.table_name)
         .to eq 'people' }
-
-      it 'finds a join association respecting polymorphism' do
-        parent = subject.send(join_base)
-        reflection = Note.reflect_on_association(:notable)
-
-        expect(subject.find_join_association_respecting_polymorphism(
-          reflection, parent, Person))
-          .to eq subject.send(method, join_associations).first
-      end
     end
 
     context 'with polymorphic belongs_to join and nested symbol join' do


### PR DESCRIPTION
`{find,build}_join_association_respecting_polymorphism` are no longer
used since existed them for Active Record 3.2 and 4.0.