### PR TITLE
Don't return association if table is nil

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -268,7 +268,7 @@ module Ransack
 
         def find_association(name, parent = @base, klass = nil)
           @join_dependency.instance_variable_get(:@join_root).children.detect do |assoc|
-            assoc.reflection.name == name &&
+            assoc.reflection.name == name && assoc.table &&
             (@associations_pot.empty? || @associations_pot[assoc] == parent || !@associations_pot.key?(assoc)) &&
             (!klass || assoc.reflection.klass == klass)
           end


### PR DESCRIPTION
Returning an association here where `table == nil` will result in a subsequent `undefined method '[]' for nil:NilClass` being thrown in [`get_attribute`](https://github.com/activerecord-hackery/ransack/blob/1bd2f31d5a1c462172bad464bb7c0b15e2074cde/lib/ransack/nodes/bindable.rb#L38-L38) due to [`Ransack::Adapters::ActiveRecord::context#table_for`](https://github.com/activerecord-hackery/ransack/blob/1bd2f31d5a1c462172bad464bb7c0b15e2074cde//Users/christiangregg/dev/ransack/lib/ransack/adapters/active_record/context.rb#L69-L69) returning nil.

Falling back to `build_association` works as expected.

Related #947 