### PR TITLE
Don't return association if table is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Don't return association if table is nil
+  PR [952](https://github.com/activerecord-hackery/ransack/pull/952)
+
+  *Christian Gregg*
+
 ## Version 2.0.0 - 2018-08-09
 
 * Add support for Active Record 5.2.1

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -268,7 +268,7 @@ module Ransack
 
         def find_association(name, parent = @base, klass = nil)
           @join_dependency.instance_variable_get(:@join_root).children.detect do |assoc|
-            assoc.reflection.name == name &&
+            assoc.reflection.name == name && assoc.table &&
             (@associations_pot.empty? || @associations_pot[assoc] == parent || !@associations_pot.key?(assoc)) &&
             (!klass || assoc.reflection.klass == klass)
           end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -316,6 +316,11 @@ module Ransack
         .to eq s.result(distinct: true).send(all_or_load)
       end
 
+      it 'evaluates joins with belongs_to join' do
+        s = Person.joins(:parent).ransack(parent_name_eq: 'Ernie').result(distinct: true)
+        expect(s).to be_an ActiveRecord::Relation
+      end
+
       private
 
         def remove_quotes_and_backticks(str)


### PR DESCRIPTION
Added spec to #951, closes #947 