### PR TITLE
Remove unused/useless constant aliases

### DIFF
--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -5,7 +5,6 @@ if defined?(::ActiveRecord)
 
     JoinDependency  = ::ActiveRecord::Associations::JoinDependency
     JoinAssociation = ::ActiveRecord::Associations::JoinDependency::JoinAssociation
-    JoinBase = ::ActiveRecord::Associations::JoinDependency::JoinBase
   end
 
   require 'polyamorous/tree_node'
@@ -22,10 +21,4 @@ if defined?(::ActiveRecord)
   Polyamorous::JoinDependency.send(:prepend, Polyamorous::JoinDependencyExtensions)
   Polyamorous::JoinDependency.singleton_class.send(:prepend, Polyamorous::JoinDependencyExtensions::ClassMethods)
   Polyamorous::JoinAssociation.send(:prepend, Polyamorous::JoinAssociationExtensions)
-
-  Polyamorous::JoinBase.class_eval do
-    if method_defined?(:active_record)
-      alias_method :base_klass, :active_record
-    end
-  end
 end

--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -1,12 +1,7 @@
 if defined?(::ActiveRecord)
   module Polyamorous
-    if defined?(Arel::InnerJoin)
-      InnerJoin = Arel::InnerJoin
-      OuterJoin = Arel::OuterJoin
-    else
-      InnerJoin = Arel::Nodes::InnerJoin
-      OuterJoin = Arel::Nodes::OuterJoin
-    end
+    InnerJoin = Arel::Nodes::InnerJoin
+    OuterJoin = Arel::Nodes::OuterJoin
 
     JoinDependency  = ::ActiveRecord::Associations::JoinDependency
     JoinAssociation = ::ActiveRecord::Associations::JoinDependency::JoinAssociation

--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -8,15 +8,9 @@ if defined?(::ActiveRecord)
       OuterJoin = Arel::Nodes::OuterJoin
     end
 
-    if defined?(::ActiveRecord::Associations::JoinDependency)
-      JoinDependency  = ::ActiveRecord::Associations::JoinDependency
-      JoinAssociation = ::ActiveRecord::Associations::JoinDependency::JoinAssociation
-      JoinBase = ::ActiveRecord::Associations::JoinDependency::JoinBase
-    else
-      JoinDependency  = ::ActiveRecord::Associations::ClassMethods::JoinDependency
-      JoinAssociation = ::ActiveRecord::Associations::ClassMethods::JoinDependency::JoinAssociation
-      JoinBase = ::ActiveRecord::Associations::ClassMethods::JoinDependency::JoinBase
-    end
+    JoinDependency  = ::ActiveRecord::Associations::JoinDependency
+    JoinAssociation = ::ActiveRecord::Associations::JoinDependency::JoinAssociation
+    JoinBase = ::ActiveRecord::Associations::JoinDependency::JoinBase
   end
 
   require 'polyamorous/tree_node'

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -7,11 +7,6 @@ module Ransack
     module ActiveRecord
       class Context < ::Ransack::Context
 
-        # Because the AR::Associations namespace is insane
-        if defined? ::ActiveRecord::Associations::JoinDependency
-          JoinDependency = ::ActiveRecord::Associations::JoinDependency
-        end
-
         def initialize(object, options = {})
           super
           if ::ActiveRecord::VERSION::STRING < Constants::RAILS_5_2
@@ -235,19 +230,19 @@ module Ransack
           join_list = join_nodes + convert_join_strings_to_ast(relation.table, string_joins)
 
           if ::ActiveRecord::VERSION::STRING < Constants::RAILS_5_2_0
-            join_dependency = JoinDependency.new(relation.klass, association_joins, join_list)
+            join_dependency = Polyamorous::JoinDependency.new(relation.klass, association_joins, join_list)
             join_nodes.each do |join|
               join_dependency.send(:alias_tracker).aliases[join.left.name.downcase] = 1
             end
           elsif ::ActiveRecord::VERSION::STRING == Constants::RAILS_5_2_0
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, relation.table.name, join_list)
-            join_dependency = JoinDependency.new(relation.klass, relation.table, association_joins, alias_tracker)
+            join_dependency = Polyamorous::JoinDependency.new(relation.klass, relation.table, association_joins, alias_tracker)
             join_nodes.each do |join|
               join_dependency.send(:alias_tracker).aliases[join.left.name.downcase] = 1
             end
           else
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, relation.table.name, join_list)
-            join_dependency = JoinDependency.new(relation.klass, relation.table, association_joins)
+            join_dependency = Polyamorous::JoinDependency.new(relation.klass, relation.table, association_joins)
             join_dependency.instance_variable_set(:@alias_tracker, alias_tracker)
             join_nodes.each do |join|
               join_dependency.send(:alias_tracker).aliases[join.left.name.downcase] = 1
@@ -276,7 +271,7 @@ module Ransack
 
         def build_association(name, parent = @base, klass = nil)
           if ::ActiveRecord::VERSION::STRING < Constants::RAILS_5_2_0
-            jd = JoinDependency.new(
+            jd = Polyamorous::JoinDependency.new(
               parent.base_klass,
               Polyamorous::Join.new(name, @join_type, klass),
               []
@@ -284,7 +279,7 @@ module Ransack
             found_association = jd.join_root.children.last
           elsif ::ActiveRecord::VERSION::STRING == Constants::RAILS_5_2_0
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, parent.table.name, [])
-            jd = JoinDependency.new(
+            jd = Polyamorous::JoinDependency.new(
               parent.base_klass,
               parent.base_klass.arel_table,
               Polyamorous::Join.new(name, @join_type, klass),
@@ -292,7 +287,7 @@ module Ransack
             )
             found_association = jd.instance_variable_get(:@join_root).children.last
           else
-            jd = JoinDependency.new(
+            jd = Polyamorous::JoinDependency.new(
               parent.base_klass,
               parent.base_klass.arel_table,
               Polyamorous::Join.new(name, @join_type, klass),


### PR DESCRIPTION
* Remove unused constant aliases for `ActiveRecord::Associations::ClassMethods::*`

`ActiveRecord::Associations::ClassMethods::*` had already been moved to
`ActiveRecord::Associations::*` since Rails 3.1.

See rails/rails@b171b9e

* Remove unused constant aliases for `Arel::{InnerJoin,OuterJoin}`

`Arel::Nodes::{InnerJoin,OuterJoin}` exists since Arel 2.2 still today.

https://github.com/rails/arel/blame/v9.0.0/lib/arel/nodes/inner_join.rb
https://github.com/rails/arel/blame/v9.0.0/lib/arel/nodes/outer_join.rb

* Remove useless constant alias for `JoinDependency`

Originally it looks like for using shorter name in this file since
`ActiveRecord::Associations::ClassMethods::JoinDependency` was too long.

I think we can just use `Polyamorous::JoinDependency` existent alias.

* Remove unused constant alias for `JoinBase`

`JoinBase#active_record` no longer exist since Rails 4.0.

See rails/rails#10151