### PR TITLE
improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ which are defined in
 <% end %>
 ```
 
+The argument of `f.search_field` has to be in this form:
+ `attribute_name[_or_attribute_name]..._predicate` 
+ 
+where `[_or_another_attribute_name]...` means any repetition of `_or_` plus the name of the attribute.
+
 `cont` (contains) and `start` (starts with) are just two of the available
 search predicates. See
 [Constants](https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/constants.rb)


### PR DESCRIPTION
I'm a beginner in rails, and I am used to be a mobile developer. I'm submitting this pull request because i found not so clear how to construct the symbol argument of search_field. I had to read all the wiki and it took me an hour to understand how predicates combines together. I think it would be useful for beginners having on the main readme a little more formal explanation about the syntax. The content of the pr is what i figured out and it may be incomplete or wrong, but definitely it would be useful to have something like that on the read me so users can use this wonderful gem more easily! 