### PR TITLE
copy polyamorous files for ActiveRecord 5.2.2

### DIFF
--- a/lib/polyamorous/activerecord_5.2.2_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_5.2.2_ruby_2/join_association.rb
@@ -1,0 +1,31 @@
+# active_record_5.2.1_ruby_2/join_association.rb
+
+module Polyamorous
+  module JoinAssociationExtensions
+    include SwappingReflectionClass
+    def self.prepended(base)
+      base.class_eval { attr_reader :join_type }
+    end
+
+    def initialize(reflection, children, polymorphic_class = nil, join_type = Arel::Nodes::InnerJoin)
+      @join_type = join_type
+      if polymorphic_class && ::ActiveRecord::Base > polymorphic_class
+        swapping_reflection_klass(reflection, polymorphic_class) do |reflection|
+          super(reflection, children)
+          self.reflection.options[:polymorphic] = true
+        end
+      else
+        super(reflection, children)
+      end
+    end
+
+    def build_constraint(klass, table, key, foreign_table, foreign_key)
+      if reflection.polymorphic?
+        super(klass, table, key, foreign_table, foreign_key)
+        .and(foreign_table[reflection.foreign_type].eq(reflection.klass.name))
+      else
+        super(klass, table, key, foreign_table, foreign_key)
+      end
+    end
+  end
+end

--- a/lib/polyamorous/activerecord_5.2.2_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.2.2_ruby_2/join_dependency.rb
@@ -1,0 +1,57 @@
+# active_record_5.2.1_ruby_2/join_dependency.rb
+
+module Polyamorous
+  module JoinDependencyExtensions
+    # Replaces ActiveRecord::Associations::JoinDependency#build
+    #
+    def build(associations, base_klass)
+      associations.map do |name, right|
+        if name.is_a? Join
+          reflection = find_reflection base_klass, name.name
+          reflection.check_validity!
+          reflection.check_eager_loadable!
+
+          klass = if reflection.polymorphic?
+            name.klass || base_klass
+          else
+            reflection.klass
+          end
+          JoinAssociation.new(reflection, build(right, klass), name.klass, name.type)
+        else
+          reflection = find_reflection base_klass, name
+          reflection.check_validity!
+          reflection.check_eager_loadable!
+
+          if reflection.polymorphic?
+            raise ActiveRecord::EagerLoadPolymorphicError.new(reflection)
+          end
+          JoinAssociation.new(reflection, build(right, reflection.klass))
+        end
+      end
+    end
+
+    module ClassMethods
+      # Prepended before ActiveRecord::Associations::JoinDependency#walk_tree
+      #
+      def walk_tree(associations, hash)
+        case associations
+        when TreeNode
+          associations.add_to_tree(hash)
+        when Hash
+          associations.each do |k, v|
+            cache =
+              if TreeNode === k
+                k.add_to_tree(hash)
+              else
+                hash[k] ||= {}
+              end
+            walk_tree(v, cache)
+          end
+        else
+          super(associations, hash)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Using Rails 5.2.2 breaks ransack due to a search path dependancy in Polyamorous.

This fix simply copies the existing modules for AR 5.2.1 to fix the load path issue causing by upgrading to Rails 5.2.2
