### PR TITLE
Proposal: Don't ignore unknown conditions by default.

### DIFF
--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -28,7 +28,7 @@ module Ransack
 
     self.options = {
       :search_key => :q,
-      :ignore_unknown_conditions => true,
+      :ignore_unknown_conditions => false,
       :hide_sort_order_indicators => false,
       :up_arrow => '&#9660;'.freeze,
       :down_arrow => '&#9650;'.freeze,


### PR DESCRIPTION
Hi,

Big fan of ransack! We've been using it at my company for a while now. One thing that we bumped into recently is that, by default, if you pass in a malformed parameter to ransack, it will ignore it, and by default return the whole collection. That's proved to be an unsafe way to operate for us, since it opened up clients who use our APIs to the possibility that they'll have a badly named search term, and instead of scoping the data to one person, they'll get a bunch of people's data. We did some digging, and discovered `ignore_unknown_conditions`, and will use that in all our apps. I wanted to see if you all would be open to changing the default behavior, since it seems like having `ignore_unknown_conditions => false` is a safer default than the current one. 

Seems like other people bumped into this at times unexpected behavior in the past.

https://github.com/activerecord-hackery/ransack/issues/852
https://github.com/activerecord-hackery/ransack/issues/535

Either way, thank you maintainers for your continued work on this gem. Cheers!