### PR TITLE
Support Rails 6 in #sort_link helper

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -145,7 +145,7 @@ module Ransack
         private
 
           def parameters_hash(params)
-            if ::ActiveRecord::VERSION::MAJOR == 5 && params.respond_to?(:to_unsafe_h)
+            if ::ActiveRecord::VERSION::MAJOR >= 5 && params.respond_to?(:to_unsafe_h)
               params.to_unsafe_h
             else
               params


### PR DESCRIPTION
Currently in Rails 6.0.0.beta1 it dies with error:
`ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash`

This small fix allows it to work correctly