### PR TITLE
Fix wrong table alias when using nested join.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fix wrong table alias when using nested join. for ActiveRecord >= 5.2
+  PR [374](https://github.com/activerecord-hackery/ransack/pull/374)
+
+  *hiichan*
+
 ## Version 2.1.1 - 2018-12-05
 
 * Add `arabic` translation

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -312,7 +312,7 @@ module Ransack
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, parent.table.name, [])
             jd = Polyamorous::JoinDependency.new(
               parent.base_klass,
-              parent.base_klass.arel_table,
+              parent.table,
               Polyamorous::Join.new(name, @join_type, klass),
               alias_tracker
             )
@@ -320,7 +320,7 @@ module Ransack
           else
             jd = Polyamorous::JoinDependency.new(
               parent.base_klass,
-              parent.base_klass.arel_table,
+              parent.table,
               Polyamorous::Join.new(name, @join_type, klass),
             )
             found_association = jd.instance_variable_get(:@join_root).children.last

--- a/polyamorous/lib/polyamorous/activerecord_5.2.0_ruby_2/join_dependency.rb
+++ b/polyamorous/lib/polyamorous/activerecord_5.2.0_ruby_2/join_dependency.rb
@@ -48,7 +48,7 @@ module Polyamorous
       }
 
       joins.concat outer_joins.flat_map { |oj|
-        if join_root.match? oj.join_root
+        if join_root.match?(oj.join_root) && join_root.table.name == oj.join_root.table.name
           walk(join_root, oj.join_root)
         else
           oj.join_root.children.flat_map { |child|


### PR DESCRIPTION
Fix wrong table alias when using nested join.
only ActiveRecord >= 5.2

#374 

please review the PR