### PR TITLE
Don't escape period characters with wildcard searches in mysql2

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/constants.rb
+++ b/lib/ransack/adapters/active_record/ransack/constants.rb
@@ -102,8 +102,11 @@ module Ransack
     # replace % \ to \% \\
     def escape_wildcards(unescaped)
       case ActiveRecord::Base.connection.adapter_name
-      when "Mysql2".freeze, "PostgreSQL".freeze
-        # Necessary for PostgreSQL and MySQL
+      when "Mysql2".freeze
+        # Necessary for MySQL
+        unescaped.to_s.gsub(/([\\%_])/, '\\\\\\1')
+      when "PostgreSQL".freeze
+        # Necessary for PostgreSQL
         unescaped.to_s.gsub(/([\\%_.])/, '\\\\\\1')
       else
         unescaped

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -126,7 +126,7 @@ module Ransack
         (if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
           /"people"."name" ILIKE '%\\%\\.\\_\\\\%'/
         elsif ActiveRecord::Base.connection.adapter_name == "Mysql2"
-          /`people`.`name` LIKE '%\\\\%\\\\.\\\\_\\\\\\\\%'/
+          /`people`.`name` LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
          /"people"."name" LIKE '%%._\\%'/
         end) do
@@ -145,7 +145,7 @@ module Ransack
         (if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
           /"people"."name" NOT ILIKE '%\\%\\.\\_\\\\%'/
         elsif ActiveRecord::Base.connection.adapter_name == "Mysql2"
-          /`people`.`name` NOT LIKE '%\\\\%\\\\.\\\\_\\\\\\\\%'/
+          /`people`.`name` NOT LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
          /"people"."name" NOT LIKE '%%._\\%'/
         end) do


### PR DESCRIPTION
ransack is currently escaping period characters in mysql2. This is not correct and makes it impossible to search for things with periods in it (like email addresses).  In my limited experience with Postgres I believe it's correct to escape it there -- my patch splits the Postgres vs Mysql2 logic so the escaping for Postgres is left unchanged.


```
irb(main):001:0> unescaped = "je_rry.walsh|h%"
irb(main):002:0>          unescaped.to_s.gsub(/([\\%_.])/, '\\\\\\1')
=> "je\\_rry\\.walsh|h\\%"
irb(main):003:0>          unescaped.to_s.gsub(/([\\%_])/, '\\\\\\1')                                                                                                              
=> "je\\_rry.walsh|h\\%"
```

Only % and _ should be escaped since these are the only pattern characters supported in mysql:
https://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html
