### PR TITLE
Fix readme for ransackable scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,8 +717,6 @@ class Employee < ActiveRecord::Base
       %i(activated hired_since)
     end
   end
-
-  private_class_method :ransackable_scopes
 end
 
 Employee.ransack({ activated: true, hired_since: '2013-01-01' })


### PR DESCRIPTION
I found mistake in readme for `ransackable_scopes`. If i set private_class_method ransackable_scopes doesnt work and i get error `NoMethodError (undefined method `ransackable_scopes' for #<Skill::ActiveRecord_Relation:0x0000563b3bc7d860>)`