### PR TITLE
Fix custom predicates with 'not_in' arel predicate

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -43,7 +43,7 @@ module Ransack
 
         def in_predicate?(predicate)
           return unless defined?(Arel::Nodes::Casted)
-          predicate.class == Arel::Nodes::In
+          predicate.class == Arel::Nodes::In || predicate.class == Arel::Nodes::NotIn
         end
 
         def casted_array?(predicate)

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -381,6 +381,20 @@ module Ransack
       end
     end
 
+    context "defining custom predicates" do
+      describe "with 'not_in' arel predicate" do
+        before do
+          Ransack.configure {|c| c.add_predicate "not_in_csv", arel_predicate: "not_in", formatter: proc { |v| v.split(",") } }
+        end
+
+        it 'generates a value IS NOT NULL query' do
+          @s.name_not_in_csv = ["a", "b"]
+          field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+          expect(@s.result.to_sql).to match /#{field} NOT IN \('a', 'b'\)/
+        end
+      end
+    end
+
     private
 
       def test_boolean_equality_for(boolean_value)


### PR DESCRIPTION
Query with predicates defined with 'not_in' arel predicate results with an error "TypeError: can't quote Array"
  activerecord-5.2.2/lib/active_record/connection_adapters/abstract/quoting.rb:179:in `_quote'