### PR TITLE
correct azerbaijani translations

### DIFF
--- a/lib/ransack/locale/az.yml
+++ b/lib/ransack/locale/az.yml
@@ -1,4 +1,4 @@
-tr:
+az:
   ransack:
     search: "axtar"
     predicate: "təsdiqlə"


### PR DESCRIPTION
Corrects the wrong key in translations ```az``` instead of ```tr```