### PR TITLE
Fix failing specs on local machine [fix #1023]

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -186,6 +186,8 @@ module Ransack
             correlated_key = correlated_key.left.left
           elsif correlated_key.is_a? Arel::Nodes::Equality
             correlated_key = correlated_key.left
+          elsif correlated_key.is_a? Arel::Nodes::Grouping
+            correlated_key = join_root.right.expr.right.left
           else
             correlated_key
           end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -238,9 +238,9 @@ module Ransack
         real_query = remove_quotes_and_backticks(s.to_sql)
 
         expect(real_query)
-          .to include "LEFT OUTER JOIN articles ON articles.person_id = people.id"
+          .to match(%r{LEFT OUTER JOIN articles ON (\('default_scope' = 'default_scope'\) AND )?articles.person_id = people.id})
         expect(real_query)
-          .to include "LEFT OUTER JOIN articles articles_people ON articles_people.person_id = parents_people.id"
+          .to match(%r{LEFT OUTER JOIN articles articles_people ON (\('default_scope' = 'default_scope'\) AND )?articles_people.person_id = parents_people.id})
         expect(real_query)
           .to include "people.name = 'person_name_query'"
         expect(real_query)


### PR DESCRIPTION
Since the structure of Node returned by ActiveReocrd changed from 54de9b1, the spec execution failed.

refs: https://github.com/rails/rails/commit/54de9b1e4f5823bf22001be60efcb996ce6d260b