### PR TITLE
Support for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 2.5
 
 env:
+  - RAILS=6-0-stable DB=sqlite3
+  - RAILS=6-0-stable DB=mysql
+  - RAILS=6-0-stable DB=postgres
+
   - RAILS=5-2-stable DB=sqlite3
   - RAILS=5-2-stable DB=mysql
   - RAILS=5-2-stable DB=postgres

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ else
     gem 'actionpack'
   end
 end
-gem 'mysql2', '~> 0.4.4'
+gem 'mysql2', '~> 0.5.2'
 
 group :test do
   # TestUnit was removed from Ruby 2.2 but still needed for testing Rails 3.x.

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rake'
 
-rails = ENV['RAILS'] || '5-2-stable'
+rails = ENV['RAILS'] || '6-0-stable'
 
 gem 'pry'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,14 +16,14 @@ when /\// # A path
   gem 'activerecord', path: "#{rails}/activerecord", require: false
   gem 'actionpack', path: "#{rails}/actionpack"
 when /^v/ # A tagged version
-  git 'git://github.com/rails/rails.git', :tag => rails do
+  git 'https://github.com/rails/rails.git', :tag => rails do
     gem 'activesupport'
     gem 'activemodel'
     gem 'activerecord', require: false
     gem 'actionpack'
   end
 else
-  git 'git://github.com/rails/rails.git', :branch => rails do
+  git 'https://github.com/rails/rails.git', :branch => rails do
     gem 'activesupport'
     gem 'activemodel'
     gem 'activerecord', require: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ you're reading the documentation for the master branch with the latest features.
 
 ## Getting started
 
-Ransack is compatible with Rails 5.0, 5.1 and 5.2 on Ruby 2.2 and later.
+Ransack is compatible with Rails 6.0, 5.0, 5.1 and 5.2 on Ruby 2.2 and later.
 If you are using Rails <5.0 use the 1.8 line of Ransack.
 If you are using Ruby 1.8 or an earlier JRuby and run into compatibility
 issues, you can use an earlier version of Ransack, say, up to 1.3.0.

--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -48,6 +48,7 @@ module Ransack
     RAILS_5_1           = '5.1'.freeze
     RAILS_5_2           = '5.2'.freeze
     RAILS_5_2_0         = '5.2.0'.freeze
+    RAILS_6_0           = '6.0.0.rc1'.freeze
 
     RANSACK_SLASH_SEARCHES = 'ransack/searches'.freeze
     RANSACK_SLASH_SEARCHES_SLASH_SEARCH = 'ransack/searches/search'.freeze

--- a/polyamorous/lib/polyamorous.rb
+++ b/polyamorous/lib/polyamorous.rb
@@ -12,8 +12,8 @@ if defined?(::ActiveRecord)
   require 'polyamorous/swapping_reflection_class'
 
   ar_version = ::ActiveRecord::VERSION::STRING[0,3]
-  ar_version = ::ActiveRecord::VERSION::STRING[0,5] if ar_version >= "5.2"
-  ar_version = "5.2.1" if ::ActiveRecord::VERSION::STRING >= "5.2.1"
+  ar_version = ::ActiveRecord::VERSION::STRING[0,5] if ar_version >= "5.2" && ::ActiveRecord::VERSION::STRING < "6.0"
+  ar_version = "5.2.1" if ::ActiveRecord::VERSION::STRING >= "5.2.1" && ::ActiveRecord::VERSION::STRING < "6.0"
 
   %w(join_association join_dependency).each do |file|
     require "polyamorous/activerecord_#{ar_version}_ruby_2/#{file}"

--- a/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/join_association.rb
+++ b/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/join_association.rb
@@ -1,0 +1,2 @@
+# active_record_6.0_ruby_2/join_association
+require 'polyamorous/activerecord_5.2.1_ruby_2/join_association'

--- a/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/join_dependency.rb
+++ b/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/join_dependency.rb
@@ -1,0 +1,81 @@
+# active_record_6.0_ruby_2/join_dependency.rb
+
+module Polyamorous
+  module JoinDependencyExtensions
+    # Replaces ActiveRecord::Associations::JoinDependency#build
+    def build(associations, base_klass)
+      associations.map do |name, right|
+        if name.is_a? Join
+          reflection = find_reflection base_klass, name.name
+          reflection.check_validity!
+          reflection.check_eager_loadable!
+
+          klass = if reflection.polymorphic?
+            name.klass || base_klass
+          else
+            reflection.klass
+          end
+          JoinAssociation.new(reflection, build(right, klass), name.klass, name.type)
+        else
+          reflection = find_reflection base_klass, name
+          reflection.check_validity!
+          reflection.check_eager_loadable!
+
+          if reflection.polymorphic?
+            raise ActiveRecord::EagerLoadPolymorphicError.new(reflection)
+          end
+          JoinAssociation.new(reflection, build(right, reflection.klass))
+        end
+      end
+    end
+
+    def join_constraints(joins_to_add, alias_tracker)
+      @alias_tracker = alias_tracker
+
+      construct_tables!(join_root)
+      joins = make_join_constraints(join_root, join_type)
+
+      joins.concat joins_to_add.flat_map { |oj|
+        construct_tables!(oj.join_root)
+        if join_root.match?(oj.join_root) && join_root.table.name == oj.join_root.table.name
+          walk join_root, oj.join_root, oj.join_type
+        else
+          make_join_constraints(oj.join_root, oj.join_type)
+        end
+      }
+    end
+
+    private
+      def make_constraints(parent, child, join_type = Arel::Nodes::OuterJoin)
+        foreign_table = parent.table
+        foreign_klass = parent.base_klass
+        join_type = child.join_type || join_type if join_type == Arel::Nodes::InnerJoin
+        joins = child.join_constraints(foreign_table, foreign_klass, join_type, alias_tracker)
+        joins.concat child.children.flat_map { |c| make_constraints(child, c, join_type) }
+      end
+
+    module ClassMethods
+      # Prepended before ActiveRecord::Associations::JoinDependency#walk_tree
+      #
+      def walk_tree(associations, hash)
+        case associations
+        when TreeNode
+          associations.add_to_tree(hash)
+        when Hash
+          associations.each do |k, v|
+            cache =
+              if TreeNode === k
+                k.add_to_tree(hash)
+              else
+                hash[k] ||= {}
+              end
+            walk_tree(v, cache)
+          end
+        else
+          super(associations, hash)
+        end
+      end
+    end
+
+  end
+end

--- a/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/reflection.rb
+++ b/polyamorous/lib/polyamorous/activerecord_6.0_ruby_2/reflection.rb
@@ -1,0 +1,2 @@
+# active_record_6.0_ruby_2/reflection.rb
+require 'polyamorous/activerecord_5.2.0_ruby_2/reflection'

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'
-  s.add_development_dependency 'sqlite3', '~> 1.3.3'
+  s.add_development_dependency 'sqlite3', ENV['RAILS'] == '6-0-stable' ? '~> 1.4.1' : '~> 1.3.3'
   s.add_development_dependency 'pg', '~> 0.21'
   s.add_development_dependency 'mysql2', '0.3.20'
   s.add_development_dependency 'pry', '0.10'

--- a/spec/helpers/polyamorous_helper.rb
+++ b/spec/helpers/polyamorous_helper.rb
@@ -3,7 +3,11 @@ module PolyamorousHelper
     Polyamorous::JoinAssociation.new reflection, children, klass
   end
 
-  if ActiveRecord::VERSION::STRING > "5.2.0"
+  if ActiveRecord::VERSION::STRING >= "6.0.0.rc1"
+    def new_join_dependency(klass, associations = {})
+      Polyamorous::JoinDependency.new klass, klass.arel_table, associations, Polyamorous::InnerJoin
+    end
+  elsif ActiveRecord::VERSION::STRING > "5.2.0"
     def new_join_dependency(klass, associations = {})
       Polyamorous::JoinDependency.new klass, klass.arel_table, associations
     end

--- a/spec/ransack/join_dependency_spec.rb
+++ b/spec/ransack/join_dependency_spec.rb
@@ -79,7 +79,7 @@ module Polyamorous
     end
 
     context '#left_outer_join in Rails 5 overrides join type specified',
-            if: ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR < 2 do
+            if: ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MAJOR < 6 && ActiveRecord::VERSION::MINOR < 2 do
 
       let(:join_type_class) do
         new_join_dependency(


### PR DESCRIPTION
Closes #1021

Rails 6 is still under development and breaking changes are happening even in RC versions.  Just a month a go this pull request https://github.com/rails/rails/pull/36120 was merged after `6.0.0.rc1` was released.

This branch is compatible with latest `6-0-stable` branch , which means it will _probably_ be compatible with Rails `6.0.0.rc2` when its released if no future changes are made.

CI will pass if https://github.com/activerecord-hackery/ransack/issues/1024 is merged.