### PR TITLE
gemspec: Drop EOL property rubyforge_project

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
   s.license     = 'MIT'
 
-  s.rubyforge_project = "ransack"
-
   s.add_dependency 'actionpack', '>= 5.0'
   s.add_dependency 'activerecord', '>= 5.0'
   s.add_dependency 'activesupport', '>= 5.0'


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.