### PR TITLE
Fix for #1042 - tests will not run unless RAILS is defined.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 2.5
 
 env:
+  - DB=sqlite3
+  - DB=mysql
+  - DB=postgres
+
   - RAILS=6-0-stable DB=sqlite3
   - RAILS=6-0-stable DB=mysql
   - RAILS=6-0-stable DB=postgres

--- a/polyamorous/polyamorous.gemspec
+++ b/polyamorous/polyamorous.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 1.6.5'
-  s.add_development_dependency 'sqlite3', '~> 1.3.3'
+  s.add_development_dependency 'sqlite3', !ENV['RAILS'] || ENV['RAILS'] == '6-0-stable' ? '~> 1.4.1' : '~> 1.3.3'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'machinist', '~> 1.0.6'
   s.add_development_dependency 'faker', '~> 0.9.5'
-  s.add_development_dependency 'sqlite3', ENV['RAILS'] == '6-0-stable' ? '~> 1.4.1' : '~> 1.3.3'
+  s.add_development_dependency 'sqlite3', !ENV['RAILS'] || ENV['RAILS'] == '6-0-stable' ? '~> 1.4.1' : '~> 1.3.3'
   s.add_development_dependency 'pg', '~> 0.21'
   s.add_development_dependency 'mysql2', '0.3.20'
   s.add_development_dependency 'pry', '0.10'


### PR DESCRIPTION
This is a pull request to fix #1042. This issue means that
the following commands
```
bundle install
bundle exec rake spec
```
raise an exception when run on a cloned master branch of the repository.

The problem was caused by a change to the default version of Rails. This change meant that the ransack gemspec incorrectly sets the version of sqlite3 when the RAILS env variable is undefined.

The fix was to alter the gemspec to set the correct version of sqlite3.

In order to prevent this issue reoccurring three more tests were added to .travis.yml to make sure the tests pass when the RAILS variable is not set.

There are a couple of issues for the ransack team to consider:

- The version  of sqlite3 specified in the polyamorous gemspec is not dynamically set. This does not seem to matter, but I am not sure that it is OK to leave this to what looks like a side-effect of the bundling process
- It is possible to implement the ```sqlite3_version``` method as a single line, on the same line as the ```gem 'sqlit3'``` declaration, but it would be a very long line.
- I did look at using GEM::Version to compare the different versions, so this code would not need to be modified with Rails 6-1-stable is released, but there are differing formats e.g. ```6-0-stable``` vs ```5.2.1``` used in travis.yml, so it adds further complication.

Please let me know if you would like me to make any changes.

