### PR TITLE
Update constants.rb

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -48,7 +48,7 @@ module Ransack
     RAILS_5_1           = '5.1'.freeze
     RAILS_5_2           = '5.2'.freeze
     RAILS_5_2_0         = '5.2.0'.freeze
-    RAILS_6_0           = '6.0.0.rc1'.freeze
+    RAILS_6_0           = '6.0.0'.freeze
 
     RANSACK_SLASH_SEARCHES = 'ransack/searches'.freeze
     RANSACK_SLASH_SEARCHES_SLASH_SEARCH = 'ransack/searches/search'.freeze


### PR DESCRIPTION
Rails 6.0.0 has been released. Updating an existing 6.0.0.RC2 application had an issue with the constant.