### PR TITLE
Fix CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,6 @@ addons:
   code_climate:
     repo_token: 8b701c4364d51a0217105e08c06922d600cec3d9e60d546a89e3ddfe46e0664e
   postgresql: "9.6"
+
+services:
+  - mysql


### PR DESCRIPTION
I'm guessing because of infrastructural changes in TravisCI, `mysql` does not seem started by default, so the CI is failing in the setup step.

This PR makes sure mysql is started explicitly.

With this PR CI no longer fails in the `before_script` step, but instead shows a bunch of failures later on, that should get fixed by other PRs.