### PR TITLE
Refactor gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.6.0
+  - 2.6.3
 
 services:
   - mysql

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake'
 rails = ENV['RAILS'] || '6-0-stable'
 
 gem 'faker', '~> 0.9.5'
-gem 'sqlite3', ::Gem::Version.new(ENV['RAILS']&.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
+gem 'sqlite3', ::Gem::Version.new(rails.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 0.21'
 gem 'pry', '0.10'
 gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ rails = ENV['RAILS'] || '6-0-stable'
 
 gem 'faker', '~> 0.9.5'
 gem 'sqlite3', ::Gem::Version.new(rails.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
-gem 'pg', '~> 0.21'
+gem 'pg', '~> 1.0'
 gem 'pry', '0.10'
 gem 'byebug'
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,6 @@ gem 'pg', '~> 1.0'
 gem 'pry', '0.10'
 gem 'byebug'
 
-# Provide timezone information on Windows
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-
 case rails
 when /\// # A path
   gem 'activesupport', path: "#{rails}/activesupport"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,12 @@ gem 'rake'
 
 rails = ENV['RAILS'] || '6-0-stable'
 
-gem 'pry'
+gem 'faker', '~> 0.9.5'
+gem 'sqlite3', ::Gem::Version.new(ENV['RAILS']&.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
+gem 'pg', '~> 0.21'
+gem 'mysql2', '0.3.20'
+gem 'pry', '0.10'
+gem 'byebug'
 
 # Provide timezone information on Windows
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
@@ -33,6 +38,8 @@ end
 gem 'mysql2', '~> 0.5.2'
 
 group :test do
+  gem 'machinist', '~> 1.0.6'
+  gem 'rspec', '~> 3'
   # TestUnit was removed from Ruby 2.2 but still needed for testing Rails 3.x.
   gem 'test-unit', '~> 3.0' if RUBY_VERSION >= '2.2'
   gem 'simplecov', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ rails = ENV['RAILS'] || '6-0-stable'
 gem 'faker', '~> 0.9.5'
 gem 'sqlite3', ::Gem::Version.new(ENV['RAILS']&.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 0.21'
-gem 'mysql2', '0.3.20'
 gem 'pry', '0.10'
 gem 'byebug'
 

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -19,14 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 5.0'
   s.add_dependency 'i18n'
   s.add_dependency 'polyamorous', Ransack::VERSION.to_s
-  s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'machinist', '~> 1.0.6'
-  s.add_development_dependency 'faker', '~> 0.9.5'
-  s.add_development_dependency 'sqlite3', ::Gem::Version.new(ENV['RAILS']&.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
-  s.add_development_dependency 'pg', '~> 0.21'
-  s.add_development_dependency 'mysql2', '0.3.20'
-  s.add_development_dependency 'pry', '0.10'
-  s.add_development_dependency 'byebug'
 
   s.files         = `git ls-files`.split("\n")
 


### PR DESCRIPTION
Hei! I initially prepared this patch to fix not being able to point to ransack's master branch from my Gemfile unless I define an `ENV["RAILS"]` environment variable.

That seems fixed by #1058, but in any case, this implements a set of better practices when managing your gemspec.

In general, development dependencies fit better in your Gemfile, because they are only considered for development, an never affect end users like it happened here. Also, gemspecs don't have the feature of "conditional dependencies", which was probably the intention for the `sqlite3` dependency here.