### PR TITLE
Drop old rubies support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Drop support for rubies under 2.3.
+  PR [#1070](https://github.com/activerecord-hackery/ransack/pull/1070)
+
 ## 2.3.0 - 2019-08-18
 
 * Arabic translations PR [979](https://github.com/activerecord-hackery/ransack/pull/979)

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,5 @@ gem 'mysql2', '~> 0.5.2'
 group :test do
   gem 'machinist', '~> 1.0.6'
   gem 'rspec', '~> 3'
-  # TestUnit was removed from Ruby 2.2 but still needed for testing Rails 3.x.
-  gem 'test-unit', '~> 3.0' if RUBY_VERSION >= '2.2'
   gem 'simplecov', :require => false
 end

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ you're reading the documentation for the master branch with the latest features.
 
 Ransack is compatible with Rails 6.0, 5.0, 5.1 and 5.2 on Ruby 2.3 and later.
 If you are using Rails <5.0 use the 1.8 line of Ransack.
-If you are using Ruby 1.8 or an earlier JRuby and run into compatibility
-issues, you can use an earlier version of Ransack, say, up to 1.3.0.
+If you are using Ruby 2.2 or an earlier JRuby and run into compatibility
+issues, you can use an earlier version of Ransack, say, up to 2.3.0.
 
 Ransack works out-of-the-box with Active Record and also features limited
 support for Mongoid 4 and 5 (without associations, further details

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ you're reading the documentation for the master branch with the latest features.
 
 ## Getting started
 
-Ransack is compatible with Rails 6.0, 5.0, 5.1 and 5.2 on Ruby 2.2 and later.
+Ransack is compatible with Rails 6.0, 5.0, 5.1 and 5.2 on Ruby 2.3 and later.
 If you are using Rails <5.0 use the 1.8 line of Ransack.
 If you are using Ruby 1.8 or an earlier JRuby and run into compatibility
 issues, you can use an earlier version of Ransack, say, up to 1.3.0.

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/activerecord-hackery/ransack"
   s.summary     = %q{Object-based searching for Active Record and Mongoid (currently).}
   s.description = %q{Ransack is the successor to the MetaSearch gem. It improves and expands upon MetaSearch's functionality, but does not have a 100%-compatible API.}
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.3'
   s.license     = 'MIT'
 
   s.add_dependency 'actionpack', '>= 5.0'


### PR DESCRIPTION
I want to create a PR to fix some issues with (unreleased) ruby 2.7, but I want to use String#+@, which is only available since ruby 2.3.

I can create a different patch (backwards compatible with all currently supported rubies) using `String#dup`, but since ruby 1.9, 2.0, 2.1 and 2.2 reached their end of life a while ago, I figure we could drop support for those.