### PR TITLE
Use String#+@ before mutating the result of Symbol#to_s

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -108,7 +108,7 @@ module Ransack
       alias :g= :groupings=
 
       def method_missing(method_id, *args)
-        method_name = method_id.to_s.dup
+        method_name = +method_id.to_s
         writer = method_name.sub!(/\=$/, ''.freeze)
         if attribute_method?(method_name)
           if writer


### PR DESCRIPTION
This fixes the following spec failure when running activeadmin tests against the (unreleased) ruby 2.7:

```
Failures:

  1) ActiveAdmin::ResourceController::Sidebars without skip_sidebar! before filter does not set @skip_sidebar
     Failure/Error: template.content_tag :div, template.capture(&block), wrapper_html_options
     
     ActionView::Template::Error:
       can't modify frozen String: "category_id_eq"
     # ./.bundle/ruby/2.7.0/gems/ransack-2.3.0/lib/ransack/nodes/grouping.rb:112:in `sub!'
     # ./.bundle/ruby/2.7.0/gems/ransack-2.3.0/lib/ransack/nodes/grouping.rb:112:in `method_missing'
     # ./.bundle/ruby/2.7.0/gems/ransack-2.3.0/lib/ransack/search.rb:98:in `method_missing'
     # ./.bundle/ruby/2.7.0/gems/ransack-2.3.0/lib/ransack/helpers/form_builder.rb:19:in `value'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/tags/select.rb:18:in `block in render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/tags/select.rb:18:in `fetch'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/tags/select.rb:18:in `render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/form_options_helper.rb:165:in `select'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/form_options_helper.rb:832:in `select'
     # ./.bundle/ruby/2.7.0/gems/formtastic-3.1.5/lib/formtastic/inputs/select_input.rb:173:in `select_html'
     # ./.bundle/ruby/2.7.0/gems/formtastic-3.1.5/lib/formtastic/inputs/select_input.rb:168:in `block in to_html'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:45:in `block in capture'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:209:in `with_output_buffer'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:45:in `capture'
     # ./lib/active_admin/inputs/filters/base.rb:12:in `input_wrapping'
     # ./.bundle/ruby/2.7.0/gems/formtastic-3.1.5/lib/formtastic/inputs/select_input.rb:166:in `to_html'
     # ./.bundle/ruby/2.7.0/gems/formtastic-3.1.5/lib/formtastic/helpers/input_helper.rb:242:in `input'
     # ./lib/active_admin/filters/forms.rb:14:in `filter'
     # ./lib/active_admin/filters/forms.rb:64:in `block (2 levels) in active_admin_filters_form_for'
     # ./lib/active_admin/filters/forms.rb:57:in `each'
     # ./lib/active_admin/filters/forms.rb:57:in `block in active_admin_filters_form_for'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:45:in `block in capture'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:209:in `with_output_buffer'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/capture_helper.rb:45:in `capture'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/helpers/form_helper.rb:452:in `form_for'
     # ./lib/active_admin/filters/forms.rb:56:in `active_admin_filters_form_for'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element.rb:181:in `method_missing'
     # ./lib/active_admin/filters/resource_extension.rb:168:in `block in filters_sidebar_section'
     # ./lib/active_admin/views/components/sidebar_section.rb:25:in `instance_exec'
     # ./lib/active_admin/views/components/sidebar_section.rb:25:in `build_sidebar_content'
     # ./lib/active_admin/views/components/sidebar_section.rb:13:in `build'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:30:in `block in build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:49:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:26:in `build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:39:in `insert_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:14:in `sidebar_section'
     # ./lib/active_admin/views/components/sidebar.rb:9:in `map'
     # ./lib/active_admin/views/components/sidebar.rb:9:in `build'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:30:in `block in build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:49:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:26:in `build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:39:in `insert_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:14:in `sidebar'
     # ./lib/active_admin/views/pages/base.rb:82:in `block in build_page_content'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:31:in `block in build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:49:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:26:in `build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:39:in `insert_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:14:in `div'
     # ./lib/active_admin/views/pages/base.rb:80:in `build_page_content'
     # ./lib/active_admin/views/pages/base.rb:57:in `block (2 levels) in build_page'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:31:in `block in build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:49:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:26:in `build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:39:in `insert_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:14:in `div'
     # ./lib/active_admin/views/pages/base.rb:53:in `block in build_page'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:49:in `with_current_arbre_element'
     # ./lib/active_admin/views/pages/base.rb:52:in `build_page'
     # ./lib/active_admin/views/pages/base.rb:9:in `build'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:30:in `block in build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:92:in `with_current_arbre_element'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:26:in `build_tag'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/element/builder_methods.rb:39:in `insert_tag'
     # ./app/views/active_admin/resource/index.html.arb:2:in `block in __home_deivid__ode_activeadmin_app_views_active_admin_resource_index_html_arb___1127073531988461853_46975342052920'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:45:in `instance_eval'
     # ./.bundle/ruby/2.7.0/gems/arbre-1.2.1/lib/arbre/context.rb:45:in `initialize'
     # ./app/views/active_admin/resource/index.html.arb:1:in `new'
     # ./app/views/active_admin/resource/index.html.arb:1:in `__home_deivid__ode_activeadmin_app_views_active_admin_resource_index_html_arb___1127073531988461853_46975342052920'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/base.rb:274:in `_run'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/template.rb:185:in `block in render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications.rb:182:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/template.rb:386:in `instrument_render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/template.rb:183:in `render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/template_renderer.rb:59:in `block (2 levels) in render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/abstract_renderer.rb:89:in `block in instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications.rb:180:in `block in instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications.rb:180:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/abstract_renderer.rb:88:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/template_renderer.rb:58:in `block in render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/template_renderer.rb:66:in `render_with_layout'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/template_renderer.rb:57:in `render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/template_renderer.rb:13:in `render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/renderer.rb:61:in `render_template_to_object'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/renderer/renderer.rb:29:in `render_to_object'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/rendering.rb:118:in `block in _render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/base.rb:304:in `in_rendering_context'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/rendering.rb:117:in `_render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/streaming.rb:219:in `_render_template'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/rendering.rb:103:in `render_to_body'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/abstract_controller/rendering.rb:25:in `render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/rendering.rb:36:in `render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/core_ext/benchmark.rb:14:in `block in ms'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/core_ext/benchmark.rb:14:in `ms'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:44:in `block in render'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:85:in `cleanup_view_runtime'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activerecord/lib/active_record/railties/controller_runtime.rb:34:in `cleanup_view_runtime'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:43:in `render'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/action_controller/responder.rb:240:in `default_render'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/action_controller/responder.rb:172:in `to_html'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/responders/flash_responder.rb:109:in `to_html'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/action_controller/responder.rb:165:in `respond'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/action_controller/responder.rb:158:in `call'
     # ./.bundle/ruby/2.7.0/gems/responders-3.0.0/lib/action_controller/respond_with.rb:213:in `respond_with'
     # ./.bundle/ruby/2.7.0/gems/inherited_resources-1.11.0/lib/inherited_resources/actions.rb:7:in `index'
     # ./lib/active_admin/resource_controller/streaming.rb:12:in `index'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/abstract_controller/base.rb:196:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/rendering.rb:30:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/callbacks.rb:135:in `run_callbacks'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/abstract_controller/callbacks.rb:41:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/rescue.rb:22:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:33:in `block in process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications.rb:180:in `block in instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activesupport/lib/active_support/notifications.rb:180:in `instrument'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal/params_wrapper.rb:245:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/activerecord/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/abstract_controller/base.rb:136:in `process'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionview/lib/action_view/rendering.rb:39:in `process'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/metal.rb:191:in `dispatch'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/test_case.rb:514:in `process'
     # ./.bundle/ruby/2.7.0/gems/devise-4.7.1/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # ./.bundle/ruby/2.7.0/gems/devise-4.7.1/lib/devise/test/controller_helpers.rb:102:in `catch'
     # ./.bundle/ruby/2.7.0/gems/devise-4.7.1/lib/devise/test/controller_helpers.rb:102:in `_catch_warden'
     # ./.bundle/ruby/2.7.0/gems/devise-4.7.1/lib/devise/test/controller_helpers.rb:35:in `process'
     # ./.bundle/ruby/2.7.0/bundler/gems/rails-94fe2430da93/actionpack/lib/action_controller/test_case.rb:392:in `get'
     # ./spec/unit/resource_controller/sidebars_spec.rb:12:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # FrozenError:
     #   can't modify frozen String: "category_id_eq"
     #   ./.bundle/ruby/2.7.0/gems/ransack-2.3.0/lib/ransack/nodes/grouping.rb:112:in `sub!'
```

The relevant ruby-core change is https://github.com/ruby/ruby/pull/2437.

This PR does not support rubies under 2.3, so it would need #1070 to be acceptable.