### PR TITLE
Fix running tests against a Rails clone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,17 @@ gem 'rake'
 
 rails = ENV['RAILS'] || '6-0-stable'
 
+rails_version = case rails
+                when /\// # A path
+                  File.read(File.join(rails, "RAILS_VERSION"))
+                when /^v/ # A tagged version
+                  rails.gsub(/^v/, '')
+                else
+                  rails
+                end
+
 gem 'faker', '~> 0.9.5'
-gem 'sqlite3', ::Gem::Version.new(rails.gsub(/^v/, '')) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
+gem 'sqlite3', ::Gem::Version.new(rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 1.0'
 gem 'pry', '0.10'
 gem 'byebug'
@@ -14,8 +23,10 @@ gem 'byebug'
 case rails
 when /\// # A path
   gem 'activesupport', path: "#{rails}/activesupport"
+  gem 'activemodel', path: "#{rails}/activemodel"
   gem 'activerecord', path: "#{rails}/activerecord", require: false
   gem 'actionpack', path: "#{rails}/actionpack"
+  gem 'actionview', path: "#{rails}/actionview"
 when /^v/ # A tagged version
   git 'https://github.com/rails/rails.git', :tag => rails do
     gem 'activesupport'


### PR DESCRIPTION
There were two problems:

* An absolute path is not a something `Gem::VERSION` understands, so in
the "path case", read the `RAILS_VERSION` file from the Rails clone and
use that.

* In the "path case" there were some missing dependencies. Add them to
the Gemfile.