### PR TITLE
Respect ransack_alias when sorting related tables

### DIFF
--- a/lib/ransack/nodes/sort.rb
+++ b/lib/ransack/nodes/sort.rb
@@ -31,7 +31,7 @@ module Ransack
       end
 
       def name=(name)
-        @name = name
+        @name = context.ransackable_alias(name) || name
         context.bind(self, name)
       end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -24,12 +24,19 @@ else
   )
 end
 
+class PersonAlias < ActiveRecord::Base
+  belongs_to :person
+end
+
 class Person < ActiveRecord::Base
   default_scope { order(id: :desc) }
   belongs_to :parent, class_name: 'Person', foreign_key: :parent_id
   has_many   :children, class_name: 'Person', foreign_key: :parent_id
   has_many   :articles
   has_many   :story_articles
+  has_many   :aliases, class_name: 'PersonAlias'
+
+  ransack_alias :aka, :aliases_name
 
   has_many :published_articles, ->{ where(published: true) },
       class_name: "Article"
@@ -192,6 +199,11 @@ module Schema
         t.boolean  :terms_and_conditions, default: false
         t.boolean  :true_or_false, default: true
         t.timestamps null: false
+      end
+
+      create_table :person_aliases, force: true do |t|
+        t.integer :person_id
+        t.string :name
       end
 
       create_table :articles, force: true do |t|


### PR DESCRIPTION
This is an attempt at adding the functionality added in [this PR](https://github.com/activerecord-hackery/ransack/pull/766), but also adding tests.