### PR TITLE
Bump 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 2.3.1 - 2010-01-01
+## 2.3.2 - 2020-01-11
+
+* Breakfix to bump Polyamorous
+
+## 2.3.1 - 2020-01-11
 
 * Drop support for Active Record 5.0, 5.1, and 5.2.0.
   PR [#1073](https://github.com/activerecord-hackery/ransack/pull/1073)

--- a/lib/ransack/version.rb
+++ b/lib/ransack/version.rb
@@ -1,3 +1,3 @@
 module Ransack
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end

--- a/polyamorous/lib/polyamorous/version.rb
+++ b/polyamorous/lib/polyamorous/version.rb
@@ -1,3 +1,3 @@
 module Polyamorous
-  VERSION = '2.3.0'
+  VERSION = '2.3.2'
 end


### PR DESCRIPTION
Bump to 2.3.2 as both Ransack and Polyamorous need to be bumped at the same time and a Rubygem cannot be republished.

https://github.com/activerecord-hackery/ransack/issues/1094