### PR TITLE
Additional Rails vers in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
 language: ruby
 
 rvm:
-  - 2.6.5
+  - 2.6.6
 
 services:
   - mysql
 
 env:
-  - RAILS=6-0-stable DB=sqlite3
-  - RAILS=6-0-stable DB=mysql
-  - RAILS=6-0-stable DB=postgres
+  - RAILS=v6.0.2 DB=sqlite3
+  - RAILS=v6.0.2 DB=mysql
+  - RAILS=v6.0.2 DB=postgres
+
+  - RAILS=v6.0.1 DB=sqlite3
+  - RAILS=v6.0.1 DB=mysql
+  - RAILS=v6.0.1 DB=postgres
 
   - RAILS=v6.0.0 DB=sqlite3
   - RAILS=v6.0.0 DB=mysql
   - RAILS=v6.0.0 DB=postgres
+
+  - RAILS=6-0-stable DB=sqlite3
+  - RAILS=6-0-stable DB=mysql
+  - RAILS=6-0-stable DB=postgres
 
   - RAILS=5-2-stable DB=sqlite3
   - RAILS=5-2-stable DB=mysql
@@ -22,12 +30,6 @@ env:
   - RAILS=v5.2.3 DB=sqlite3
   - RAILS=v5.2.3 DB=mysql
   - RAILS=v5.2.3 DB=postgres
-
-matrix:
-  allow_failures:
-    - env: RAILS=6-0-stable DB=sqlite3
-    - env: RAILS=6-0-stable DB=mysql
-    - env: RAILS=6-0-stable DB=postgres
 
 before_script:
   - if [ "$DB" = "mysql" ];


### PR DESCRIPTION
- Include tests against Rails 6.0.1 and 6.0.2
- Remove 'allow failure' section from CI
- Thanks to @gregmolnar for [most of the code](https://github.com/activerecord-hackery/ransack/pull/1100)