### PR TITLE
Fix Ruby 2.7 deprecation warnings

### DIFF
--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -50,7 +50,7 @@ module Ransack
 
         defaults << options.delete(:default) if options[:default]
         options.reverse_merge! count: 1, default: defaults
-        I18n.translate(defaults.shift, options.merge(interpolations))
+        I18n.translate(defaults.shift, **options.merge(interpolations))
       end
 
       def association(key, options = {})
@@ -67,7 +67,7 @@ module Ransack
           end
         defaults << context.traverse(key).model_name.human
         options = { :count => 1, :default => defaults }
-        I18n.translate(defaults.shift, options)
+        I18n.translate(defaults.shift, **options)
       end
 
       private
@@ -83,7 +83,7 @@ module Ransack
         options = { count: 1, default: defaults }
         interpolations = build_interpolations(associated_class)
 
-        I18n.translate(defaults.shift, options.merge(interpolations))
+        I18n.translate(defaults.shift, **options.merge(interpolations))
       end
 
       def default_attribute_name


### PR DESCRIPTION
In Ruby 2.7 passing the last argument as an options hash if the receiver uses keyword arguments is no longer allowed and throws a warning.

This PR applies the recommended fix of adding `**` to covert the options hash into the correct keyword arg format.

There may be more deprecation warnings to fix in other parts of the codebase but these were the ones that jumped out to me right away.