### PR TITLE
Fixes polymorphic joins.

### DIFF
--- a/lib/polyamorous/activerecord_5.2_ruby_2/reflection.rb
+++ b/lib/polyamorous/activerecord_5.2_ruby_2/reflection.rb
@@ -1,11 +1,20 @@
 module Polyamorous
   module ReflectionExtensions
-    def build_join_constraint(table, foreign_table)
-      if polymorphic?
-        super(table, foreign_table)
-        .and(foreign_table[foreign_type].eq(klass.name))
-      else
-        super(table, foreign_table)
+    if ActiveRecord.version > ::Gem::Version.new('5.2.3')
+      def join_scope(table, foreign_table, foreign_klass)
+        if respond_to?(:polymorphic?) && polymorphic?
+          super.where!(foreign_table[foreign_type].eq(klass.name))
+        else
+          super
+        end
+      end
+    else
+      def build_join_constraint(table, foreign_table)
+        if polymorphic?
+          super.and(foreign_table[foreign_type].eq(klass.name))
+        else
+          super
+        end
       end
     end
   end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -257,6 +257,9 @@ module Ransack
       let(:children_people_name_field) {
         "#{quote_table_name("children_people")}.#{quote_column_name("name")}"
       }
+      let(:notable_type_field) {
+        "#{quote_table_name("notes")}.#{quote_column_name("notable_type")}"
+      }
       it 'evaluates conditions contextually' do
         s = Search.new(Person, children_name_eq: 'Ernie')
         expect(s.result).to be_an ActiveRecord::Relation
@@ -328,6 +331,7 @@ module Ransack
         s = Search.new(Note, notable_of_Person_type_name_eq: 'Ernie').result
         expect(s).to be_an ActiveRecord::Relation
         expect(s.to_sql).to match /#{people_name_field} = 'Ernie'/
+        expect(s.to_sql).to match /#{notable_type_field} = 'Person'/
       end
 
       it 'evaluates nested conditions' do


### PR DESCRIPTION
* Polymorphic joins have been missing a critical join constraint that
is responsible for only returning polymorphic records of the specified
type.

* Override ActiveRecord::Reflection::AbstractReflection#join_scope to
add this constraint if the reflection is polymorphic.

Polymorphic searching has been **broken in Ransack** since https://github.com/rails/rails/commit/49bcb008cbaf0fa2db727ae58e7e27015a7ae02c.

This PR closes https://github.com/activerecord-hackery/ransack/issues/1039, closes https://github.com/activerecord-hackery/ransack/issues/1120, and closes https://github.com/activerecord-hackery/ransack/pull/1077.

This bug has been a source of great frustration for our organization, and presumably many users of this library are completely unaware of the incorrect queries being formed by this library. I have no idea how long these Polymorphic hacks on ActiveRecord will last, but hopefully this will be caught in the future with the test addition in this PR.