### PR TITLE
Add ransack! method which raises error if passed unknown condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+* Add `ActiveRecord::Base.ransack!` which raises error if passed unknown condition
+
+  *Aaron Lipman*
+
 ## 2.4.0 - 2020-11-27
 
 *

--- a/README.md
+++ b/README.md
@@ -670,6 +670,43 @@ Trying it out in `rails console`:
 
 That's it! Now you know how to whitelist/blacklist various elements in Ransack.
 
+### Handling unknown predicates or attributes
+
+By default, Ransack will ignore any unknown predicates or attributes:
+
+```ruby
+Article.ransack(unknown_attr_eq: 'Ernie').result.to_sql
+=> SELECT "articles".* FROM "articles"
+```
+
+Ransack may be configured to raise an error if passed an unknown predicate or
+attributes, by setting the `ignore_unknown_conditions` option to `false` in your
+Ransack initializer file at `config/initializers/ransack.rb`:
+
+```ruby
+Ransack.configure do |c|
+  # Raise errors if a query contains an unknown predicate or attribute.
+  # Default is true (do not raise error on unknown conditions).
+  c.ignore_unknown_conditions = false
+end
+```
+
+```ruby
+Article.ransack(unknown_attr_eq: 'Ernie')
+# ArgumentError (Invalid search term unknown_attr_eq)
+```
+
+As an alternative to setting a global configuration option, the `.ransack!`
+class method also raises an error if passed an unknown condition:
+
+```ruby
+Article.ransack!(unknown_attr_eq: 'Ernie')
+# ArgumentError: Invalid search term unknown_attr_eq
+```
+
+This is equivilent to the `ignore_unknown_conditions` configuration option,
+except it may be applied on a case-by-case basis.
+
 ### Using Scopes/Class Methods
 
 Continuing on from the preceding section, searching by scopes requires defining

--- a/README.md
+++ b/README.md
@@ -41,27 +41,14 @@ gem 'ransack', github: 'activerecord-hackery/ransack'
 
 ## Usage
 
-Ransack can be used in one of two modes, simple or advanced.
+Ransack can be used in one of two modes, simple or advanced. For
+searching/filtering not requiring complex boolean logic, Ransack's simple
+mode should meet your needs.
+
+If you're coming from MetaSearch (Ransack's predecessor), refer to the
+[Updating From MetaSearch](#updating-from-metasearch) section
 
 ### Simple Mode
-
-This mode works much like MetaSearch, for those of you who are familiar with
-it, and requires very little setup effort.
-
-If you're coming from MetaSearch, things to note:
-
-  1. The default param key for search params is now `:q`, instead of `:search`.
-  This is primarily to shorten query strings, though advanced queries (below)
-  will still run afoul of URL length limits in most browsers and require a
-  switch to HTTP POST requests. This key is [configurable](https://github.com/activerecord-hackery/ransack/wiki/Configuration).
-
-  2. `form_for` is now `search_form_for`, and validates that a Ransack::Search
-  object is passed to it.
-
-  3. Common ActiveRecord::Relation methods are no longer delegated by the
-  search object. Instead, you will get your search results (an
-  ActiveRecord::Relation in the case of the ActiveRecord adapter) via a call to
-  `Ransack#result`.
 
 #### In your controller
 
@@ -81,6 +68,20 @@ def index
 
   # or use `to_a.uniq` to remove duplicates (can also be done in the view):
   @people = @q.result.includes(:articles).page(params[:page]).to_a.uniq
+end
+```
+
+##### Default search parameter
+
+Ransack uses a default `:q` param key for search params. This may be changed by
+setting the `search_key` option in a Ransack initializer file (typically
+`config/initializers/ransack.rb`):
+
+```
+Ransack.configure do |c|
+  # Change default search parameter key name.
+  # Default key name is :q
+  c.search_key = :query
 end
 ```
 
@@ -902,6 +903,28 @@ en:
       namespace_article:
         title: Old Ransack Namespaced Title
 ```
+
+### Updating From MetaSearch
+
+Ransack works much like MetaSearch, for those of you who are familiar with
+it, and requires very little setup effort.
+
+If you're coming from MetaSearch, things to note:
+
+  1. The default param key for search params is now `:q`, instead of `:search`.
+  This is primarily to shorten query strings, though advanced queries (below)
+  will still run afoul of URL length limits in most browsers and require a
+  switch to HTTP POST requests. This key is
+  [configurable](default-search-parameter) via setting the `search_key` option
+  in your Ransack intitializer file.
+
+  2. `form_for` is now `search_form_for`, and validates that a Ransack::Search
+  object is passed to it.
+
+  3. Common ActiveRecord::Relation methods are no longer delegated by the
+  search object. Instead, you will get your search results (an
+  ActiveRecord::Relation in the case of the ActiveRecord adapter) via a call to
+  `Ransack#result`.
 
 ## Mongoid
 

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -18,6 +18,10 @@ module Ransack
           Search.new(self, params, options)
         end
 
+        def ransack!(params = {}, options = {})
+          ransack(params, options.merge(ignore_unknown_conditions: false))
+        end
+
         def ransacker(name, opts = {}, &block)
           self._ransackers = _ransackers.merge name.to_s => Ransacker
             .new(self, name, opts, &block)

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -30,6 +30,7 @@ module Ransack
         )
       @scope_args = {}
       @sorts ||= []
+      @ignore_unknown_conditions = options[:ignore_unknown_conditions] == false ? false : true
       build(params.with_indifferent_access)
     end
 
@@ -45,7 +46,7 @@ module Ransack
           base.send("#{key}=", value)
         elsif @context.ransackable_scope?(key, @context.object)
           add_scope(key, value)
-        elsif !Ransack.options[:ignore_unknown_conditions]
+        elsif !Ransack.options[:ignore_unknown_conditions] || !@ignore_unknown_conditions
           raise ArgumentError, "Invalid search term #{key}"
         end
       end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -122,6 +122,10 @@ module Ransack
             expect { Person.ransack('') }.to_not raise_error
           end
 
+          it 'raises exception if ransack! called with unknown condition' do
+            expect { Person.ransack!(unknown_attr_eq: 'Ernie') }.to raise_error
+          end
+
           it 'does not modify the parameters' do
             params = { name_eq: '' }
             expect { Person.ransack(params) }.not_to change { params }

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -232,7 +232,7 @@ module Ransack
       context 'with an invalid condition' do
         subject { Search.new(Person, unknown_attr_eq: 'Ernie') }
 
-        context 'when ignore_unknown_conditions is false' do
+        context 'when ignore_unknown_conditions configuration option is false' do
           before do
             Ransack.configure { |c| c.ignore_unknown_conditions = false }
           end
@@ -240,12 +240,38 @@ module Ransack
           specify { expect { subject }.to raise_error ArgumentError }
         end
 
-        context 'when ignore_unknown_conditions is true' do
+        context 'when ignore_unknown_conditions configuration option is true' do
           before do
             Ransack.configure { |c| c.ignore_unknown_conditions = true }
           end
 
           specify { expect { subject }.not_to raise_error }
+        end
+
+        subject(:with_ignore_unknown_conditions_false) {
+          Search.new(Person,
+            { unknown_attr_eq: 'Ernie' },
+            { ignore_unknown_conditions: false }
+          )
+        }
+
+        subject(:with_ignore_unknown_conditions_true) {
+          Search.new(Person,
+            { unknown_attr_eq: 'Ernie' },
+            { ignore_unknown_conditions: true }
+          )
+        }
+
+        context 'when ignore_unknown_conditions search parameter is absent' do
+          specify { expect { subject }.not_to raise_error }
+        end
+
+        context 'when ignore_unknown_conditions search parameter is false' do
+          specify { expect { with_ignore_unknown_conditions_false }.to raise_error ArgumentError }
+        end
+
+        context 'when ignore_unknown_conditions search parameter is true' do
+          specify { expect { with_ignore_unknown_conditions_true }.not_to raise_error }
         end
       end
 


### PR DESCRIPTION
**Use case:** We use Ransack for both public-facing search pages and internal purposes such as targeting bulk email deliveries. In the context of public-facing search, we'd like to be lenient with unknown/invalid search params. However, in the context of targeting bulk emails, this seems dangerous - a broken query could potentially go out to many more recipients than intended.

Thus, we'd like to be able to trigger the `ignore_unknown_conditions` config option on a case-by-case basis. (Previously requested in https://github.com/activerecord-hackery/ransack/issues/535)

I've drafted what feels like a clean implementation, although here are some other options I considered:

```ruby
# add Ransack::Search#validate!
Person.ransack(unknown_attr_eq: "Ernie").validate!.result

# pass ignore_unknown_conditions directly as param
Person.ransack(unknown_attr_eq: "Ernie", ignore_unknown_conditions: false)
```

If folks like this idea but have a different preference for implementing it, let me know and I'll adjust this PR accordingly!