### PR TITLE
Make gem compatible with old polyamorous require

### DIFF
--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -1,0 +1,2 @@
+require 'polyamorous/polyamorous'
+


### PR DESCRIPTION
By providing `polyamorous.rb` in the `lib` folder, projects that
previously depended directly on `polyamorous` can just switch the
dependency to `ransack` without changing their calls to `require`.