### PR TITLE
Remove deprecated `#search` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,32 +352,6 @@ construct much more complex search forms, such as the one on the
 [demo app](http://ransack-demo.herokuapp.com/users/advanced_search)
 (source code [here](https://github.com/activerecord-hackery/ransack_demo)).
 
-### Ransack #search method
-
-Ransack will try to make the class method `#search` available in your
-models, but if `#search` has already been defined elsewhere, you can always use
-the default `#ransack` class method. So the following are equivalent:
-
-```ruby
-Article.ransack(params[:q])
-Article.search(params[:q])
-```
-
-Users have reported issues of `#search` name conflicts with other gems, so
-the `#search` method alias will be deprecated in the next major version of
-Ransack (2.0). It's advisable to use the default `#ransack` instead.
-
-For now, if Ransack's `#search` method conflicts with the name of another
-method named `search` in your code or another gem, you may resolve it either by
-patching the `extended` class_method in `Ransack::Adapters::ActiveRecord::Base`
-to remove the line `alias :search :ransack unless base.respond_to? :search`, or
-by placing the following line in your Ransack initializer file at
-`config/initializers/ransack.rb`:
-
-```ruby
-Ransack::Adapters::ActiveRecord::Base.class_eval('remove_method :search')
-```
-
 ### Associations
 
 You can easily use Ransack to search for objects in `has_many` and `belongs_to`

--- a/lib/ransack/adapters/active_record/base.rb
+++ b/lib/ransack/adapters/active_record/base.rb
@@ -4,7 +4,6 @@ module Ransack
       module Base
 
         def self.extended(base)
-          alias :search :ransack unless base.respond_to? :search
           base.class_eval do
             class_attribute :_ransackers
             class_attribute :_ransack_aliases
@@ -14,7 +13,6 @@ module Ransack
         end
 
         def ransack(params = {}, options = {})
-          ActiveSupport::Deprecation.warn("#search is deprecated and will be removed in 2.3, please use #ransack instead") if __callee__ == :search
           Search.new(self, params, options)
         end
 

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -8,7 +8,6 @@ module Ransack
         subject { ::ActiveRecord::Base }
 
         it { should respond_to :ransack }
-        it { should respond_to :search }
 
         describe '#search' do
           subject { Person.ransack }


### PR DESCRIPTION
`#search` is deprecated in v2.1.1 and it scheduled to remove the method in v2.3.
https://github.com/activerecord-hackery/ransack/pull/975

But the method still exists in v2.3.2. So let's remove the method.

If we removed the method, users can remove the patch for `search` (`ActiveRecord::Base.class_eval('remove_method :search'`).