### PR TITLE
Use unfrozen version of symbol to string

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -108,7 +108,7 @@ module Ransack
       alias :g= :groupings=
 
       def method_missing(method_id, *args)
-        method_name = method_id.to_s
+        method_name = method_id.to_s.dup
         writer = method_name.sub!(/\=$/, ''.freeze)
         if attribute_method?(method_name)
           if writer


### PR DESCRIPTION
This change makes Ransack compatible with shopify/symbol-fstring since `Symbol#to_s` will return a frozen string literal.