### PR TITLE
Typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ List of all possible predicates
 | `*_not_cont` | Does not contain |
 | `*_not_cont_any` | Does not contain any of | |
 | `*_not_cont_all` | Does not contain all of | |
-| `*_i_cont` | Contains value with case insensitive | uses `LIKE` |
+| `*_i_cont` | Contains value with case insensitive | uses `ILIKE` |
 | `*_i_cont_any` | Contains any of values with case insensitive | |
 | `*_i_cont_all` | Contains all of values with case insensitive | |
 | `*_not_i_cont` | Does not contain with case insensitive |


### PR DESCRIPTION
I think this is a typo, should be `ILIKE`, since it's case insensitive.