### PR TITLE
Fix typo - change LIKE to ILIKE for i_cont in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ List of all possible predicates
 | `*_not_cont` | Does not contain |
 | `*_not_cont_any` | Does not contain any of | |
 | `*_not_cont_all` | Does not contain all of | |
-| `*_i_cont` | Contains value with case insensitive | uses `LIKE` |
+| `*_i_cont` | Contains value with case insensitive | uses `ILIKE` |
 | `*_i_cont_any` | Contains any of values with case insensitive | |
 | `*_i_cont_all` | Contains all of values with case insensitive | |
 | `*_not_i_cont` | Does not contain with case insensitive |


### PR DESCRIPTION
The i_cont predicate runs a case insensitive search: https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/adapters/active_record/ransack/constants.rb#L19