### PR TITLE
Run specs using a newer faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ rails_version = case rails
                   rails
                 end
 
-gem 'faker', '~> 0.9.5'
+gem 'faker', '~> 1.0'
 gem 'sqlite3', ::Gem::Version.new(rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 1.0'
 gem 'pry', '~> 0.12.2'

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -265,10 +265,12 @@ module Ransack
           # end
 
           it 'creates ransack attributes' do
+            person = Person.create!(name: 'Aric Smith')
+
             s = Person.ransack(reversed_name_eq: 'htimS cirA')
             expect(s.result.size).to eq(1)
 
-            expect(s.result.first).to eq Person.where(name: 'Aric Smith').first
+            expect(s.result.first).to eq person
           end
 
           it 'can be accessed through associations' do


### PR DESCRIPTION
This is a prerequisite for being able to run specs against Rails 6.1, since previous faker versions were holding down the i18n dependency with a requirement incompatible with newest Rails.