### PR TITLE
Adapt to quoting change in Rails

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -47,12 +47,19 @@ module Ransack
         end
 
         def casted_array?(predicate)
-          predicate.respond_to?(:val) && predicate.val.is_a?(Array)
+          (predicate.respond_to?(:value) && predicate.value.is_a?(Array)) || # Rails 6.1
+            (predicate.respond_to?(:val) && predicate.val.is_a?(Array)) # Rails 5.2, 6.0
         end
 
         def format_values_for(predicate)
-          predicate.val.map do |value|
-            value.is_a?(String) ? Arel::Nodes.build_quoted(value) : value
+          value = if predicate.respond_to?(:value)
+                    predicate.value # Rails 6.1
+                  else
+                    predicate.val # Rails 5.2, 6.0
+                  end
+
+          value.map do |val|
+            val.is_a?(String) ? Arel::Nodes.build_quoted(val) : val
           end
         end
 


### PR DESCRIPTION
I've been bisecting specs against Rails 6.1 and the first set of failures I get is:

```
Failures:

  1) Ransack::Adapters::ActiveRecord::Base#ransacker searching on an `in` predicate with a ransacker should function correctly when passing an array of ids
     Failure/Error: expect(s.result.count).to be > 0
     
       expected: > 0
            got:   0
     # ./spec/ransack/adapters/active_record/base_spec.rb:371:in `block (4 levels) in <module:ActiveRecord>'

  2) Ransack::Adapters::ActiveRecord::Base#ransacker searching on an `in` predicate with a ransacker should function correctly when passing an array of strings
     Failure/Error: expect(s.result.count).to be > 0
     
     TypeError:
       can't quote Array
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:227:in `_quote'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:14:in `quote'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:710:in `quote'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:85:in `visit_Arel_Nodes_Casted'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:741:in `block in inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each_with_index'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:704:in `visit_Array'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:524:in `visit_Arel_Nodes_In'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:15:in `visit_Arel_Nodes_In'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:741:in `block in inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each_with_index'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:177:in `collect_nodes_for'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:157:in `visit_Arel_Nodes_SelectCore'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:124:in `block in visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `inject'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/sqlite.rb:14:in `visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:11:in `accept'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:10:in `accept'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:18:in `compile'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:25:in `to_sql_and_binds'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:63:in `select_all'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:107:in `select_all'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation/calculations.rb:312:in `block in execute_simple_calculation'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation.rb:867:in `skip_query_cache_if_necessary'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation/calculations.rb:312:in `execute_simple_calculation'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation/calculations.rb:268:in `perform_calculation'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation/calculations.rb:144:in `calculate'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation/calculations.rb:51:in `count'
     # ./spec/ransack/adapters/active_record/base_spec.rb:383:in `block (4 levels) in <module:ActiveRecord>'

  3) Ransack::Predicate defining custom predicates with 'not_in' arel predicate generates a value IS NOT NULL query
     Failure/Error: expect(@s.result.to_sql).to match /#{field} NOT IN \('a', 'b'\)/
     
     TypeError:
       can't quote Array
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:227:in `_quote'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:14:in `quote'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:710:in `quote'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:85:in `visit_Arel_Nodes_Casted'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:741:in `block in inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each_with_index'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:704:in `visit_Array'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:539:in `visit_Arel_Nodes_NotIn'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:20:in `visit_Arel_Nodes_NotIn'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:741:in `block in inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `each_with_index'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:739:in `inject_join'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:177:in `collect_nodes_for'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:157:in `visit_Arel_Nodes_SelectCore'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:124:in `block in visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `each'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `inject'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:123:in `visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/sqlite.rb:14:in `visit_Arel_Nodes_SelectStatement'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/visitor.rb:11:in `accept'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:10:in `accept'
     # /home/deivid/Code/rails/activerecord/lib/arel/visitors/to_sql.rb:18:in `compile'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:34:in `to_sql_and_binds'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:13:in `to_sql'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation.rb:675:in `block in to_sql'
     # /home/deivid/Code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:245:in `unprepared_statement'
     # /home/deivid/Code/rails/activerecord/lib/active_record/relation.rb:675:in `to_sql'
     # ./spec/ransack/predicate_spec.rb:431:in `block (4 levels) in <module:Ransack>'

Finished in 1.54 seconds (files took 1.36 seconds to load)
335 examples, 3 failures, 1 pending

Failed examples:

rspec ./spec/ransack/adapters/active_record/base_spec.rb:369 # Ransack::Adapters::ActiveRecord::Base#ransacker searching on an `in` predicate with a ransacker should function correctly when passing an array of ids
rspec ./spec/ransack/adapters/active_record/base_spec.rb:378 # Ransack::Adapters::ActiveRecord::Base#ransacker searching on an `in` predicate with a ransacker should function correctly when passing an array of strings
rspec ./spec/ransack/predicate_spec.rb:428 # Ransack::Predicate defining custom predicates with 'not_in' arel predicate generates a value IS NOT NULL query
```


This is due to https://github.com/rails/rails/commit/280d6eb2e1663809aa7f743ed45abf5ef83cd5eb.

This commit should fix the issue.