### PR TITLE
Remove redundant CI entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ env:
   - RAILS=v6.0.2 DB=mysql
   - RAILS=v6.0.2 DB=postgres
 
-  - RAILS=v6.0.1 DB=sqlite3
-  - RAILS=v6.0.1 DB=mysql
-  - RAILS=v6.0.1 DB=postgres
-
-  - RAILS=v6.0.0 DB=sqlite3
-  - RAILS=v6.0.0 DB=mysql
-  - RAILS=v6.0.0 DB=postgres
-
   - RAILS=6-0-stable DB=sqlite3
   - RAILS=6-0-stable DB=mysql
   - RAILS=6-0-stable DB=postgres


### PR DESCRIPTION
We only care about the latest patch level release for each major Rails.