### PR TITLE
CI against Rails 6.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0.rc2
+          - v6.1.0
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0.rc2
+          - v6.1.0
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0.rc2
+          - v6.1.0
           - v6.0.3
           - 6-0-stable
           - 5-2-stable


### PR DESCRIPTION
This pull request enables CI against Rails 6.1.0.

Rails 6.1.0 has been released on Dec 9, 2020.
https://weblog.rubyonrails.org/2020/12/9/Rails-6-1-0-release/