### PR TITLE
Replace constant `RAILS_6_1_ALPHA` with `RAILS_6_1`

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -106,7 +106,7 @@ module Ransack
         def join_sources
           base, joins = begin
             alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, @object.table.name, [])
-            constraints   = if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1_ALPHA)
+            constraints   = if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1)
               @join_dependency.join_constraints(@object.joins_values, alias_tracker, @object.references_values)
             elsif ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_0)
               @join_dependency.join_constraints(@object.joins_values, alias_tracker)
@@ -334,7 +334,7 @@ module Ransack
           @join_dependency.instance_variable_get(:@join_root).children.push found_association
 
           # Builds the arel nodes properly for this association
-          if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1_ALPHA)
+          if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1)
             @tables_pot[found_association] = @join_dependency.construct_tables_for_association!(jd.instance_variable_get(:@join_root), found_association)
           else
             @join_dependency.send(:construct_tables!, jd.instance_variable_get(:@join_root))
@@ -348,7 +348,7 @@ module Ransack
         def extract_joins(association)
           parent = @join_dependency.instance_variable_get(:@join_root)
           reflection = association.reflection
-          join_constraints = if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1_ALPHA)
+          join_constraints = if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new(Constants::RAILS_6_1)
                                association.join_constraints_with_tables(
                                  parent.table,
                                  parent.base_klass,

--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -46,7 +46,7 @@ module Ransack
     CONT                = 'cont'.freeze
 
     RAILS_6_0           = '6.0.0'.freeze
-    RAILS_6_1_ALPHA     = '6.1.0.alpha'.freeze
+    RAILS_6_1           = '6.1.0'.freeze
 
     RANSACK_SLASH_SEARCHES = 'ransack/searches'.freeze
     RANSACK_SLASH_SEARCHES_SLASH_SEARCH = 'ransack/searches/search'.freeze


### PR DESCRIPTION
Rails 6.1.0 has been released already, Ransack does not have to consider 6.1.0.alpha version anymore.