### PR TITLE
Drop Ruby 2.5 or older versions of Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
   *Aaron Lipman*
 
+* Drop support for rubies under 2.5. PR #1189
+
 ## 2.4.0 - 2020-11-27
 
 *

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/activerecord-hackery/ransack"
   s.summary     = %q{Object-based searching for Active Record and Mongoid (currently).}
   s.description = %q{Ransack is the successor to the MetaSearch gem. It improves and expands upon MetaSearch's functionality, but does not have a 100%-compatible API.}
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.6'
   s.license     = 'MIT'
 
   s.add_dependency 'activerecord', '>= 5.2.4'


### PR DESCRIPTION
README already mentions that `Ransack is supported for Rails 6.1, 6.0,
5.2 on Ruby 2.6.6 and later.` by https://github.com/activerecord-hackery/ransack/commit/d50885772cfa9c2534c06f7edb0eb4141f2e1a4a

I'd like to get some feed back from maintainers since #1070 just dropped Ruby 2.2 or older versions of Ruby.