### PR TITLE
CI against Ruby 3.0.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.0.0
       - name: Install gems
         run: bundle install --jobs 4 --retry 3
       - name: Run RuboCop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,14 @@ jobs:
           - 5-2-stable
           - v5.2.4
         ruby:
+          - 3.0.0
           - 2.7.2
           - 2.6.6
+        exclude:
+          - rails:  v5.2.4
+            ruby:   3.0.0
+          - rails:  5-2-stable
+            ruby:   3.0.0
     env:
       DB: sqlite3
       RAILS: ${{ matrix.rails }}
@@ -45,8 +51,14 @@ jobs:
           - 5-2-stable
           - v5.2.4
         ruby:
+          - 3.0.0
           - 2.7.2
           - 2.6.6
+        exclude:
+          - rails:  v5.2.4
+            ruby:   3.0.0
+          - rails:  5-2-stable
+            ruby:   3.0.0
     env:
       DB: mysql
       RAILS: ${{ matrix.rails }}
@@ -82,8 +94,14 @@ jobs:
           - 5-2-stable
           - v5.2.4
         ruby:
+          - 3.0.0
           - 2.7.2
           - 2.6.6
+        exclude:
+          - rails:  v5.2.4
+            ruby:   3.0.0
+          - rails:  5-2-stable
+            ruby:   3.0.0
     env:
       DB: postgres
       RAILS: ${{ matrix.rails }}


### PR DESCRIPTION
This pull request runs CI against Ruby 3.0.0.
Rails 6.0.3 or higher is required to support Ruby 3 keyword arguments behavior then excluded the matrix between Ruby 3.0.0 and Rails 5.2.x.

* Rails 6.0.3 has been released!
https://weblog.rubyonrails.org/2020/5/6/Rails-6-0-3-has-been-released/
> This version fixes warnings when used with Ruby 2.7.

* Ruby 3.0.0 Released
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
> Keyword arguments are separated from other arguments.