### PR TITLE
Allow Ransack to be tested with Rails main branch

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -16,7 +16,7 @@ jobs:
           - 2.6.6
     env:
       DB: sqlite3
-      RAILS: master
+      RAILS: main
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -39,7 +39,7 @@ jobs:
           - 2.6.6
     env:
       DB: mysql
-      RAILS: master
+      RAILS: main
       MYSQL_USERNAME: root
       MYSQL_PASSWORD: root
     steps:
@@ -71,7 +71,7 @@ jobs:
           - 2.6.6
     env:
       DB: postgres
-      RAILS: master
+      RAILS: main
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: 127.0.0.1

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -1,0 +1,105 @@
+name: cronjob
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sqlite3:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 3.0.0
+          - 2.7.2
+          - 2.6.6
+    env:
+      DB: sqlite3
+      RAILS: master
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec
+
+  mysql:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 3.0.0
+          - 2.7.2
+          - 2.6.6
+    env:
+      DB: mysql
+      RAILS: master
+      MYSQL_USERNAME: root
+      MYSQL_PASSWORD: root
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Startup MySQL
+        run: |
+          sudo systemctl start mysql.service
+      - name: Setup databases
+        run: |
+          mysql --user=root --password=root --host=127.0.0.1 -e 'create database ransack collate utf8_general_ci;';
+          mysql --user=root --password=root --host=127.0.0.1 -e 'use ransack;show variables like "%character%";show variables like "%collation%";';
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec
+
+  postgres:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 3.0.0
+          - 2.7.2
+          - 2.6.6
+    env:
+      DB: postgres
+      RAILS: master
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: postgres
+      DATABASE_HOST: 127.0.0.1
+    services:
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Setup databases
+        run: |
+          psql -h localhost -p 5432 -W postgres -c 'create database ransack;' -U postgres;
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ rails_version = case rails
                 end
 
 gem 'faker', '~> 2.0'
-gem 'sqlite3', ::Gem::Version.new(rails_version == 'master' ? '6.2.0.alpha' : rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
+gem 'sqlite3', ::Gem::Version.new(rails_version == 'main' ? '6.2.0.alpha' : rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 1.0'
 gem 'pry', '~> 0.12.2'
 gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ rails_version = case rails
                 end
 
 gem 'faker', '~> 2.0'
-gem 'sqlite3', ::Gem::Version.new(rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
+gem 'sqlite3', ::Gem::Version.new(rails_version == 'master' ? '6.2.0.alpha' : rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 1.0'
 gem 'pry', '~> 0.12.2'
 gem 'byebug'

--- a/lib/polyamorous/activerecord_6.2_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_6.2_ruby_2/join_association.rb
@@ -1,0 +1,1 @@
+require 'polyamorous/activerecord_6.1_ruby_2/join_association'

--- a/lib/polyamorous/activerecord_6.2_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_6.2_ruby_2/join_dependency.rb
@@ -1,0 +1,1 @@
+require 'polyamorous/activerecord_6.1_ruby_2/join_dependency'

--- a/lib/polyamorous/activerecord_6.2_ruby_2/reflection.rb
+++ b/lib/polyamorous/activerecord_6.2_ruby_2/reflection.rb
@@ -1,0 +1,1 @@
+require 'polyamorous/activerecord_6.1_ruby_2/reflection'


### PR DESCRIPTION
This pull request allows Ransack to be tested with Rails master branch aka 6.2.0.alpha.

Let me explain some background for this change.

Ransack (polyamorous) depends on some Rails internal APIs and Rails internal APIs change without deprecation warnings. In the long term, Ransack (polyamorous) may not depend on these internal API, but as of now, what we can do is run CI against Rails master branch so that we will able to know which commits 'break' Ransack behavior.
