### PR TITLE
Bump RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Layout/SpaceInsideParens:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
 Style/RedundantReturn:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
 AllCops:
-  # TargetRubyVersion value is based on `required_ruby_version = '>= 2.3'` in the ransack.gemspec
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
 
   DisabledByDefault: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,4 @@ group :test do
   gem 'simplecov', :require => false
 end
 
-# RuboCop 0.81.0 is the last version which supports Ruby 2.3.
-# Once Ransack required_ruby_version is bumped, RuboCop version can be bumped.
-# https://github.com/rubocop-hq/rubocop/pull/7869
-gem 'rubocop', '=0.81.0', require: false
+gem 'rubocop', require: false

--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext'
 require 'ransack/configuration'
 require 'ransack/adapters'
-require 'polyamorous/polyamorous.rb'
+require 'polyamorous/polyamorous'
 
 Ransack::Adapters.object_mapper.require_constants
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'machinist/active_record'
-require 'polyamorous/polyamorous.rb'
+require 'polyamorous/polyamorous'
 require 'sham'
 require 'faker'
 require 'ransack'


### PR DESCRIPTION
This pull request bumps RuboCop version by removing version limitation because Ransack supports Ruby 2.6 or higher.

Also enabled `Style/RedundantFileExtensionInRequire` cop which is available since RuboCop 0.88.0.