### PR TITLE
Bump Faker 2 to use keyword arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ rails_version = case rails
                   rails
                 end
 
-gem 'faker', '~> 1.0'
+gem 'faker', '~> 2.0'
 gem 'sqlite3', ::Gem::Version.new(rails_version) >= ::Gem::Version.new('6-0-stable') ? '~> 1.4.1' : '~> 1.3.3'
 gem 'pg', '~> 1.0'
 gem 'pry', '~> 0.12.2'

--- a/spec/console.rb
+++ b/spec/console.rb
@@ -14,11 +14,11 @@ Sham.define do
   title    { Faker::Lorem.sentence }
   body     { Faker::Lorem.paragraph }
   salary   { |index| 30000 + (index * 1000) }
-  tag_name { Faker::Lorem.words(3).join(' ') }
-  note     { Faker::Lorem.words(7).join(' ') }
-  only_admin  { Faker::Lorem.words(3).join(' ') }
-  only_search { Faker::Lorem.words(3).join(' ') }
-  only_sort   { Faker::Lorem.words(3).join(' ') }
+  tag_name { Faker::Lorem.words(number: 3).join(' ') }
+  note     { Faker::Lorem.words(number: 7).join(' ') }
+  only_admin  { Faker::Lorem.words(number: 3).join(' ') }
+  only_search { Faker::Lorem.words(number: 3).join(' ') }
+  only_sort   { Faker::Lorem.words(number: 3).join(' ') }
   notable_id  { |id| id }
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,11 @@ Sham.define do
   title       { Faker::Lorem.sentence }
   body        { Faker::Lorem.paragraph }
   salary      { |index| 30000 + (index * 1000) }
-  tag_name    { Faker::Lorem.words(3).join(' ') }
-  note        { Faker::Lorem.words(7).join(' ') }
-  only_admin  { Faker::Lorem.words(3).join(' ') }
-  only_search { Faker::Lorem.words(3).join(' ') }
-  only_sort   { Faker::Lorem.words(3).join(' ') }
+  tag_name    { Faker::Lorem.words(number: 3).join(' ') }
+  note        { Faker::Lorem.words(number: 7).join(' ') }
+  only_admin  { Faker::Lorem.words(number: 3).join(' ') }
+  only_search { Faker::Lorem.words(number: 3).join(' ') }
+  only_sort   { Faker::Lorem.words(number: 3).join(' ') }
   notable_id  { |id| id }
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ I18n.load_path += Dir[File.join(File.dirname(__FILE__), 'support', '*.yml')]
 Dir[File.expand_path('../{helpers,support,blueprints}/*.rb', __FILE__)]
 .each { |f| require f }
 
+Faker::Config.random = Random.new(0)
 Sham.define do
   name        { Faker::Name.name }
   title       { Faker::Lorem.sentence }


### PR DESCRIPTION
This pull request bumps Faker version to 2 to use keyword arguments


- Change Faker arguments by RuboCop Faker

```ruby
$ gem install rubocop-faker
$ rubocop --require rubocop-faker --only Faker/DeprecatedArguments -a
Inspecting 70 files
....................................................C...............C.

Offenses:

spec/console.rb:17:33: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  tag_name { Faker::Lorem.words(3).join(' ') }
                                ^
spec/console.rb:18:33: C: [Corrected] Faker/DeprecatedArguments: Passing 7 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 7) instead.
  note     { Faker::Lorem.words(7).join(' ') }
                                ^
spec/console.rb:19:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_admin  { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/console.rb:20:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_search { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/console.rb:21:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_sort   { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/spec_helper.rb:25:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  tag_name    { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/spec_helper.rb:26:36: C: [Corrected] Faker/DeprecatedArguments: Passing 7 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 7) instead.
  note        { Faker::Lorem.words(7).join(' ') }
                                   ^
spec/spec_helper.rb:27:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_admin  { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/spec_helper.rb:28:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_search { Faker::Lorem.words(3).join(' ') }
                                   ^
spec/spec_helper.rb:29:36: C: [Corrected] Faker/DeprecatedArguments: Passing 3 with the 1st argument of Faker::Lorem.words is deprecated. Use keyword argument like Faker::Lorem.words(number: 3) instead.
  only_sort   { Faker::Lorem.words(3).join(' ') }
                                   ^

70 files inspected, 10 offenses detected, 10 offenses corrected
$
```


- Configure `Faker::Config.random = Random.new(0)` to avoid spec failure.
Without this configuration, this condition also finds the record whose name is `"Nereida Langworth"`. 

```ruby
$ bundle exec rspec ./spec/ransack/adapters/active_record/base_spec.rb:228
Run options: include {:locations=>{"./spec/ransack/adapters/active_record/base_spec.rb"=>[228]}}
==================================================================================
Running Ransack specs with SQLite, Active Record 6.1.0, Arel 10.0.0 and Ruby 3.0.0
==================================================================================
F

Failures:

  1) Ransack::Adapters::ActiveRecord::Base#ransack_alias makes aliases available to subclasses
     Failure/Error: expect(musicians).to eq([yngwie])

       expected: [#<Musician id: 13, parent_id: nil, name: "Yngwie Malmsteen", email: nil, only_search: nil, only_sort...eated_at: "2021-01-04 11:06:06.885783000 +0000", updated_at: "2021-01-04 11:06:06.885783000 +0000">]
            got: #<ActiveRecord::Relation [#<Musician id: 13, parent_id: nil, name: "Yngwie Malmsteen", email: nil, on...ated_at: "2021-01-04 11:06:06.379801000 +0000", updated_at: "2021-01-04 11:06:06.379801000 +0000">]>

       (compared using ==)

       Diff:
       @@ -1,34 +1,67 @@
       -[#<Musician id: 13, parent_id: nil, name: "Yngwie Malmsteen", email: nil, only_search: nil, only_sort: nil, only_admin: nil, new_start: nil, stop_end: nil, salary: nil, life_start: nil, awesome: false, terms_and_conditions: false, true_or_false: true, created_at: "2021-01-04 11:06:06.885783000 +0000", updated_at: "2021-01-04 11:06:06.885783000 +0000">]
       +[#<Musician:0x000055817362f350
       +  id: 13,
       +  parent_id: nil,
       +  name: "Yngwie Malmsteen",
       +  email: nil,
       +  only_search: nil,
       +  only_sort: nil,
       +  only_admin: nil,
       +  new_start: nil,
       +  stop_end: nil,
       +  salary: nil,
       +  life_start: nil,
       +  awesome: false,
       +  terms_and_conditions: false,
       +  true_or_false: true,
       +  created_at: 2021-01-04 11:06:06.885783 UTC,
       +  updated_at: 2021-01-04 11:06:06.885783 UTC>,
       + #<Musician:0x000055817362f120
       +  id: 5,
       +  parent_id: nil,
       +  name: "Nereida Langworth",
       +  email: "test@example.com",
       +  only_search: "ab et voluptatem",
       +  only_sort: "ab et voluptatem",
       +  only_admin: "ab et voluptatem",
       +  new_start: nil,
       +  stop_end: nil,
       +  salary: 35000,
       +  life_start: nil,
       +  awesome: false,
       +  terms_and_conditions: false,
       +  true_or_false: true,
       +  created_at: 2021-01-04 11:06:06.379801 UTC,
       +  updated_at: 2021-01-04 11:06:06.379801 UTC>]

     # ./spec/ransack/adapters/active_record/base_spec.rb:232:in `block (3 levels) in <module:ActiveRecord>'

Finished in 0.92455 seconds (files took 1.2 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/ransack/adapters/active_record/base_spec.rb:228 # Ransack::Adapters::ActiveRecord::Base#ransack_alias makes aliases available to subclasses

Coverage report generated for RSpec to /home/yahonda/src/github.com/activerecord-hackery/ransack/coverage. 160 / 192 LOC (83.33%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
$
```