### PR TITLE
Ensure relation.order method receives Arel to silence deprecation warning

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -44,9 +44,9 @@ module Ransack
               else
                 case Ransack.options[:postgres_fields_sort_option]
                 when :nulls_first
-                  scope_or_sort = scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS FIRST" : "#{scope_or_sort.to_sql} NULLS LAST"
+                  scope_or_sort = Arel.sql(scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS FIRST" : "#{scope_or_sort.to_sql} NULLS LAST")
                 when :nulls_last
-                  scope_or_sort = scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS LAST" : "#{scope_or_sort.to_sql} NULLS FIRST"
+                  scope_or_sort = Arel.sql(scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS LAST" : "#{scope_or_sort.to_sql} NULLS FIRST")
                 end
 
                 relation = relation.order(scope_or_sort)

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -585,13 +585,11 @@ module Ransack
             )
           end
 
-          context 'when fields_sort_option is set' do
-            before { Ransack.configure { |c| c.postgres_fields_sort_option = :nulls_first } }
-
-            it 'doesn\'t trigger a deprecation warning' do
-              search = Person.ransack(sorts: ['name_case_insensitive desc'])
-              expect { search.result.first }.to_not output.to_stderr
-            end
+          it 'shouldn\'t trigger a deprecation warning when fields_sort_options is set' do
+            Ransack.configure { |c| c.postgres_fields_sort_option = :nulls_first }
+            search = Person.ransack(sorts: ['name_case_insensitive desc'])
+            expect { search.result.first }.to_not output.to_stderr
+            Ransack.configure { |c| c.postgres_fields_sort_option = nil }
           end
 
           context 'case insensitive sorting' do

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -585,6 +585,15 @@ module Ransack
             )
           end
 
+          context 'when fields_sort_option is set' do
+            before { Ransack.configure { |c| c.postgres_fields_sort_option = :nulls_first } }
+
+            it 'doesn\'t trigger a deprecation warning' do
+              search = Person.ransack(sorts: ['name_case_insensitive desc'])
+              expect { search.result.first }.to_not output.to_stderr
+            end
+          end
+
           context 'case insensitive sorting' do
             it 'allows sort by desc' do
               search = Person.ransack(sorts: ['name_case_insensitive desc'])


### PR DESCRIPTION
Ransack v2.4.1 introduced the [postgres_fields_sort_option](https://github.com/activerecord-hackery/ransack/pull/1184) configuration option (an awesome feature by the way!)

That change has the side effect of converting  `scope_or_sort` from an Arel to a string. This triggers certain versions of Rails to fire a warning every time an order is applied if `postgres_fields_sort_option` is set.

This fix ensures that if the ordering is converted to a string when the `NULLS FIRST`/`NULLS LAST` is appended it is then converted back into an Arel before being passed to `relation.order`. This silences the warnings because the sql is no longer a string when it is run.

More info on the warning can be found here: https://github.com/rails/rails/issues/32995