### PR TITLE
CI against Rails 6.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0
+          - v6.1.1
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0
+          - v6.1.1
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.0
+          - v6.1.1
           - v6.0.3
           - 6-0-stable
           - 5-2-stable


### PR DESCRIPTION
This pull request runs CI against Rails 6.1.1.

https://github.com/rails/rails/releases/tag/v6.1.1