### PR TITLE
Address RSpec warning by specifying as ArgumentError

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -123,7 +123,7 @@ module Ransack
           end
 
           it 'raises exception if ransack! called with unknown condition' do
-            expect { Person.ransack!(unknown_attr_eq: 'Ernie') }.to raise_error
+            expect { Person.ransack!(unknown_attr_eq: 'Ernie') }.to raise_error(ArgumentError)
           end
 
           it 'does not modify the parameters' do


### PR DESCRIPTION
This commit addresses this RSpec warning below:

```ruby
$ bundle exec rspec spec/ransack/adapters/active_record/base_spec.rb:126
Run options: include {:locations=>{"./spec/ransack/adapters/active_record/base_spec.rb"=>[126]}}
====================================================================================
Running Ransack specs with SQLite, Active Record 6.0.3.4, Arel 10.0.0 and Ruby 2.7.2
====================================================================================
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: Invalid search term unknown_attr_eq>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/src/github.com/activerecord-hackery/ransack/spec/ransack/adapters/active_record/base_spec.rb:126:in `block (3 levels) in <module:ActiveRecord>'.
.

Finished in 0.76867 seconds (files took 1.14 seconds to load)
1 example, 0 failures
```

Refer `raise_error` matcher
https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher