### PR TITLE
[skip ci] GitHub Actions can skip CI now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,9 @@ Here's a quick guide:
         $ git config --global user.email "contributor@example.com"
 
 10. Commit your changes (`git commit -am 'Add feature/fix bug/improve docs'`).
+    If your pull request only contains documentation changes, please remember
+    to add `[skip ci]` to the beginning of your commit message so the CI
+    test suite doesn't :runner: needlessly.
 
 11. If necessary, rebase your commits into logical chunks, without errors. To
    interactively rebase and cherry-pick from, say, the last 10 commits:


### PR DESCRIPTION
According to this blog post, GitHub Actions now supports skip pull request.
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

This commit partially restores the CONTRIBUTING.md changed by #1180.