### PR TITLE
Fix for ActiveRecord::UnknownAttributeReference in ransack

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -44,9 +44,9 @@ module Ransack
               else
                 case Ransack.options[:postgres_fields_sort_option]
                 when :nulls_first
-                  scope_or_sort = scope_or_sort.direction == :asc ? ("#{scope_or_sort.to_sql} NULLS FIRST") : ("#{scope_or_sort.to_sql} NULLS LAST")
+                  scope_or_sort = scope_or_sort.direction == :asc ? Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST") : Arel.sql("#{scope_or_sort.to_sql} NULLS LAST")
                 when :nulls_last
-                  scope_or_sort = scope_or_sort.direction == :asc ? ("#{scope_or_sort.to_sql} NULLS LAST") : ("#{scope_or_sort.to_sql} NULLS FIRST")
+                  scope_or_sort = scope_or_sort.direction == :asc ? Arel.sql("#{scope_or_sort.to_sql} NULLS LAST") : Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST")
                 end
 
                 relation = relation.order(scope_or_sort)

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -44,9 +44,9 @@ module Ransack
               else
                 case Ransack.options[:postgres_fields_sort_option]
                 when :nulls_first
-                  scope_or_sort = scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS FIRST" : "#{scope_or_sort.to_sql} NULLS LAST"
+                  scope_or_sort = scope_or_sort.direction == :asc ? ("#{scope_or_sort.to_sql} NULLS FIRST") : ("#{scope_or_sort.to_sql} NULLS LAST")
                 when :nulls_last
-                  scope_or_sort = scope_or_sort.direction == :asc ? "#{scope_or_sort.to_sql} NULLS LAST" : "#{scope_or_sort.to_sql} NULLS FIRST"
+                  scope_or_sort = scope_or_sort.direction == :asc ? ("#{scope_or_sort.to_sql} NULLS LAST") : ("#{scope_or_sort.to_sql} NULLS FIRST")
                 end
 
                 relation = relation.order(scope_or_sort)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -554,6 +554,27 @@ module Ransack
 
         Ransack.options = default
       end
+
+      it "PG's sort option with double name", if: ::ActiveRecord::Base.connection.adapter_name == "PostgreSQL" do
+        default = Ransack.options.clone
+
+        s = Search.new(Person, s: 'doubled_name asc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" || \"people\".\"name\" ASC"
+
+        Ransack.configure { |c| c.postgres_fields_sort_option = :nulls_first }
+        s = Search.new(Person, s: 'doubled_name asc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" || \"people\".\"name\" ASC NULLS FIRST"
+        s = Search.new(Person, s: 'doubled_name desc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" || \"people\".\"name\" DESC NULLS LAST"
+
+        Ransack.configure { |c| c.postgres_fields_sort_option = :nulls_last }
+        s = Search.new(Person, s: 'doubled_name asc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" || \"people\".\"name\" ASC NULLS LAST"
+        s = Search.new(Person, s: 'doubled_name desc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" || \"people\".\"name\" DESC NULLS FIRST"
+
+        Ransack.options = default
+      end
     end
 
     describe '#method_missing' do


### PR DESCRIPTION
This PR fixing issue with Rails 6.1 and explicit whitelisting potentially dangerous SQL.

<img width="1375" alt="Screenshot 2021-02-23 at 14 40 37" src="https://user-images.githubusercontent.com/34511347/108852397-d9627100-75e5-11eb-9f29-9d2ed79c209c.png">

More information here:
https://api.rubyonrails.org/classes/ActiveRecord/UnknownAttributeReference.html