### PR TITLE
Drop Ruby 2.6 from cronjob as Rails 7 requires Ruby 2.7+

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -13,7 +13,6 @@ jobs:
         ruby:
           - 3.0.0
           - 2.7.2
-          - 2.6.6
     env:
       DB: sqlite3
       RAILS: main
@@ -36,7 +35,6 @@ jobs:
         ruby:
           - 3.0.0
           - 2.7.2
-          - 2.6.6
     env:
       DB: mysql
       RAILS: main
@@ -68,7 +66,6 @@ jobs:
         ruby:
           - 3.0.0
           - 2.7.2
-          - 2.6.6
     env:
       DB: postgres
       RAILS: main


### PR DESCRIPTION
This commit addresses these errors at cronjob.
https://github.com/activerecord-hackery/ransack/runs/1966021652?check_suite_focus=true

```
activesupport-7.0.0.alpha requires ruby version >= 2.7.0, which is incompatible
with the current version, ruby 2.6.6p146
Error: Process completed with exit code 5.
```

Refer
https://github.com/rails/rails/commit/6487836af8f50648a9b30ce61864c827132e5592