### PR TITLE
CI against Rails 6.1.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.1
+          - v6.1.2
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.1
+          - v6.1.2
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.1
+          - v6.1.2
           - v6.0.3
           - 6-0-stable
           - 5-2-stable


### PR DESCRIPTION
- "Rails 6.1.2 has been released!"
https://weblog.rubyonrails.org/2021/2/9/Rails-6-1-2-has-been-released/