### PR TITLE
Fix :default option in Translate.attribute method

### DIFF
--- a/lib/ransack/translate.rb
+++ b/lib/ransack/translate.rb
@@ -32,6 +32,7 @@ module Ransack
         defaults = base_ancestors.map do |klass|
           "ransack.attributes.#{i18n_key(klass)}.#{original_name}".to_sym
         end
+        defaults << options.delete(:default) if options[:default]
 
         translated_names = attribute_names.map do |name|
           attribute_name(context, name, options[:include_associations])
@@ -48,7 +49,6 @@ module Ransack
           defaults << "%{attributes}".freeze
         end
 
-        defaults << options.delete(:default) if options[:default]
         options.reverse_merge! count: 1, default: defaults
         I18n.translate(defaults.shift, **options.merge(interpolations))
       end


### PR DESCRIPTION
At the moment it's possible to pass a default translation (or translation key) to the Ransack::Translate.attribute method, however it is never actually accessed given the existing fallback using interpolated attribute/predicate names. Those interpolated strings are either "%{attributes}" or "%{attributes} %{predicate}", which never return nil. Any value passed to options[:default] is added to the end of the defaults array (after those never-nil interpolated strings), and as a result the default that is specifically supplied by the user of the gem is never actually accessed or output. This pull request is aimed at resolving that (ever-so-slight) bug