### PR TITLE
Rails 7 `default_timezone` is a module instance variable

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -314,7 +314,11 @@ module Ransack
           end
 
           it 'should function correctly with a multi-parameter attribute' do
-            ::ActiveRecord::Base.default_timezone = :utc
+            if ::ActiveRecord::VERSION::MAJOR >= 7
+              ::ActiveRecord.default_timezone = :utc
+            else
+              ::ActiveRecord::Base.default_timezone = :utc
+            end
             Time.zone = 'UTC'
 
             date = Date.current


### PR DESCRIPTION
This commit addresses the following failure.

```ruby
$ bundle exec rspec ./spec/ransack/adapters/active_record/base_spec.rb:316
Run options: include {:locations=>{"./spec/ransack/adapters/active_record/base_spec.rb"=>[316]}}
========================================================================================
Running Ransack specs with SQLite, Active Record 7.0.0.alpha, Arel 10.0.0 and Ruby 3.0.1
========================================================================================
F

Failures:

  1) Ransack::Adapters::ActiveRecord::Base#ransacker should function correctly with a multi-parameter attribute
     Failure/Error: ::ActiveRecord::Base.default_timezone = :utc

     NoMethodError:
       undefined method `default_timezone=' for ActiveRecord::Base:Class
       Did you mean?  default_timezone
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
     # ./spec/ransack/adapters/active_record/base_spec.rb:317:in `block (3 levels) in <module:ActiveRecord>'

Finished in 0.89225 seconds (files took 1.47 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/ransack/adapters/active_record/base_spec.rb:316 # Ransack::Adapters::ActiveRecord::Base#ransacker should function correctly with a multi-parameter attribute

Coverage report generated for RSpec to /home/yahonda/src/github.com/activerecord-hackery/ransack/coverage. 156 / 192 LOC (81.25%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
$
```
Fixes #1229
Refer https://github.com/rails/rails/pull/42445/commits/c6e4dbeebbfa4ea2b6d50a2ffb75f707b68aabf4