### PR TITLE
Support Rails untyped bound values change for MySQL

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -44,12 +44,12 @@ module Ransack
 
             it 'applies stringy boolean scopes with true value in an array' do
               s = Person.ransack('of_age' => ['true'])
-              expect(s.result.to_sql).to (include 'age >= 18')
+              expect(s.result.to_sql).to (include rails7_and_mysql ? %q{(age >= '18')} : 'age >= 18')
             end
 
             it 'applies stringy boolean scopes with false value in an array' do
               s = Person.ransack('of_age' => ['false'])
-              expect(s.result.to_sql).to (include 'age < 18')
+              expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age < '18'} : 'age < 18')
             end
 
             it 'ignores unlisted scopes' do
@@ -69,12 +69,12 @@ module Ransack
 
             it 'passes values to scopes' do
               s = Person.ransack('over_age' => 18)
-              expect(s.result.to_sql).to (include 'age > 18')
+              expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age > '18'} : 'age > 18')
             end
 
             it 'chains scopes' do
               s = Person.ransack('over_age' => 18, 'active' => true)
-              expect(s.result.to_sql).to (include 'age > 18')
+              expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age > '18'} : 'age > 18')
               expect(s.result.to_sql).to (include 'active = 1')
             end
 
@@ -89,12 +89,12 @@ module Ransack
 
               it 'passes true values to scopes' do
                 s = Person.ransack('over_age' => 1)
-                expect(s.result.to_sql).to (include 'age > 1')
+                expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age > '1'} : 'age > 1')
               end
 
               it 'passes false values to scopes'  do
                 s = Person.ransack('over_age' => 0)
-                expect(s.result.to_sql).to (include 'age > 0')
+                expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age > '0'} : 'age > 0')
               end
             end
 
@@ -107,12 +107,12 @@ module Ransack
 
               it 'passes true values to scopes' do
                 s = Person.ransack('over_age' => 1)
-                expect(s.result.to_sql).to (include 'age > 1')
+                expect(s.result.to_sql).to (include rails7_and_mysql ? %q{age > '1'} : 'age > 1')
               end
 
               it 'passes false values to scopes'  do
                 s = Person.ransack('over_age' => 0)
-                expect(s.result.to_sql).to (include 'age > 0')
+                expect(s.result.to_sql).to (include  rails7_and_mysql ? %q{age > '0'} : 'age > 0')
               end
             end
 
@@ -690,6 +690,10 @@ module Ransack
           it { should eq [] }
         end
 
+        private
+        def rails7_and_mysql
+          ::ActiveRecord::VERSION::MAJOR >= 7 && ENV['DB'] == 'mysql'
+        end
       end
     end
   end


### PR DESCRIPTION
This pull request fixes #1231 

Follow up rails/rails#42440
Fix #1231

This pull request addresses the following failure. 
- Note:`RAILS` path is the directory where Rails main branch checked out, MYSQL_USERNAME and MYSQL_PASSWORD depend on the configuration.

```ruby
$ RAILS=/home/yahonda/src/github.com/rails/rails DB=mysql MYSQL_USERNAME=root MYSQL_PASSWORD=root bundle exec rspec
========================================================================================
Running Ransack specs with Mysql2, Active Record 7.0.0.alpha, Arel 10.0.0 and Ruby 3.0.1
========================================================================================
............................................................DEPRECATION WARNING: ActiveRecord::Base.default_timezone= is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone=` instead.
 (called from block (3 levels) in <module:ActiveRecord> at /home/yahonda/src/github.com/activerecord-hackery/ransack/spec/ransack/adapters/active_record/base_spec.rb:317)
...................................................................................................................................................................................................................................................................................*....................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Ransack::Search#build preserves (inverts) default scope and conditions for negative subqueries
     # spec should pass, but I do not know how/where to fix lib code
     Failure/Error: expect(s.result.to_sql).to include 'default_scope'
       expected "SELECT `people`.* FROM `people` WHERE `people`.`id` NOT IN (SELECT `articles`.`person_id` FROM `arti...es`.`person_id` = `people`.`id` AND NOT (`articles`.`title` != 'Test')) ORDER BY `people`.`id` DESC" to include "default_scope"
     # ./spec/ransack/search_spec.rb:183:in `block (3 levels) in <module:Ransack>'

Finished in 4.42 seconds (files took 1.56 seconds to load)
372 examples, 0 failures, 1 pending

Coverage report generated for RSpec to /home/yahonda/src/github.com/activerecord-hackery/ransack/coverage. 1823 / 1881 LOC (96.92%) covered.
yahonda@myryzen:~/src/github.com/activerecord-hackery/ransack$ git checkout master
Switched to branch 'master'
yahonda@myryzen:~/src/github.com/activerecord-hackery/ransack$ RAILS=/home/yahonda/src/github.com/rails/rails DB=mysql MYSQL_USERNAME=root MYSQL_PASSWORD=root bundle exec rspec
========================================================================================
Running Ransack specs with Mysql2, Active Record 7.0.0.alpha, Arel 10.0.0 and Ruby 3.0.1
========================================================================================
...................................FF...FFFFFF..............DEPRECATION WARNING: ActiveRecord::Base.default_timezone= is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone=` instead.
 (called from block (3 levels) in <module:ActiveRecord> at /home/yahonda/src/github.com/activerecord-hackery/ransack/spec/ransack/adapters/active_record/base_spec.rb:317)
...................................................................................................................................................................................................................................................................................*....................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Ransack::Search#build preserves (inverts) default scope and conditions for negative subqueries
     # spec should pass, but I do not know how/where to fix lib code
     Failure/Error: expect(s.result.to_sql).to include 'default_scope'
       expected "SELECT `people`.* FROM `people` WHERE `people`.`id` NOT IN (SELECT `articles`.`person_id` FROM `arti...es`.`person_id` = `people`.`id` AND NOT (`articles`.`title` != 'Test')) ORDER BY `people`.`id` DESC" to include "default_scope"
     # ./spec/ransack/search_spec.rb:183:in `block (3 levels) in <module:Ransack>'

Failures:

  1) Ransack::Adapters::ActiveRecord::Base#search with scopes applies stringy boolean scopes with true value in an array
     Failure/Error: expect(s.result.to_sql).to (include 'age >= 18')
       expected "SELECT `people`.* FROM `people` WHERE (age >= '18') ORDER BY `people`.`id` DESC" to include "age >= 18"
     # ./spec/ransack/adapters/active_record/base_spec.rb:47:in `block (4 levels) in <module:ActiveRecord>'

  2) Ransack::Adapters::ActiveRecord::Base#search with scopes applies stringy boolean scopes with false value in an array
     Failure/Error: expect(s.result.to_sql).to (include 'age < 18')
       expected "SELECT `people`.* FROM `people` WHERE (age < '18') ORDER BY `people`.`id` DESC" to include "age < 18"
     # ./spec/ransack/adapters/active_record/base_spec.rb:52:in `block (4 levels) in <module:ActiveRecord>'

  3) Ransack::Adapters::ActiveRecord::Base#search with scopes passes values to scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 18')
       expected "SELECT `people`.* FROM `people` WHERE (age > '18') ORDER BY `people`.`id` DESC" to include "age > 18"
     # ./spec/ransack/adapters/active_record/base_spec.rb:72:in `block (4 levels) in <module:ActiveRecord>'

  4) Ransack::Adapters::ActiveRecord::Base#search with scopes chains scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 18')
       expected "SELECT `people`.* FROM `people` WHERE (age > '18') AND (active = 1) ORDER BY `people`.`id` DESC" to include "age > 18"
     # ./spec/ransack/adapters/active_record/base_spec.rb:77:in `block (4 levels) in <module:ActiveRecord>'

  5) Ransack::Adapters::ActiveRecord::Base#search with scopes with sanitize_custom_scope_booleans set to false passes true values to scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 1')
       expected "SELECT `people`.* FROM `people` WHERE (age > '1') ORDER BY `people`.`id` DESC" to include "age > 1"
     # ./spec/ransack/adapters/active_record/base_spec.rb:92:in `block (5 levels) in <module:ActiveRecord>'

  6) Ransack::Adapters::ActiveRecord::Base#search with scopes with sanitize_custom_scope_booleans set to false passes false values to scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 0')
       expected "SELECT `people`.* FROM `people` WHERE (age > '0') ORDER BY `people`.`id` DESC" to include "age > 0"
     # ./spec/ransack/adapters/active_record/base_spec.rb:97:in `block (5 levels) in <module:ActiveRecord>'

  7) Ransack::Adapters::ActiveRecord::Base#search with scopes with ransackable_scopes_skip_sanitize_args enabled for scope passes true values to scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 1')
       expected "SELECT `people`.* FROM `people` WHERE (age > '1') ORDER BY `people`.`id` DESC" to include "age > 1"
     # ./spec/ransack/adapters/active_record/base_spec.rb:110:in `block (5 levels) in <module:ActiveRecord>'

  8) Ransack::Adapters::ActiveRecord::Base#search with scopes with ransackable_scopes_skip_sanitize_args enabled for scope passes false values to scopes
     Failure/Error: expect(s.result.to_sql).to (include 'age > 0')
       expected "SELECT `people`.* FROM `people` WHERE (age > '0') ORDER BY `people`.`id` DESC" to include "age > 0"
     # ./spec/ransack/adapters/active_record/base_spec.rb:115:in `block (5 levels) in <module:ActiveRecord>'

Finished in 4.37 seconds (files took 1.57 seconds to load)
372 examples, 8 failures, 1 pending

Failed examples:

rspec ./spec/ransack/adapters/active_record/base_spec.rb:45 # Ransack::Adapters::ActiveRecord::Base#search with scopes applies stringy boolean scopes with true value in an array
rspec ./spec/ransack/adapters/active_record/base_spec.rb:50 # Ransack::Adapters::ActiveRecord::Base#search with scopes applies stringy boolean scopes with false value in an array
rspec ./spec/ransack/adapters/active_record/base_spec.rb:70 # Ransack::Adapters::ActiveRecord::Base#search with scopes passes values to scopes
rspec ./spec/ransack/adapters/active_record/base_spec.rb:75 # Ransack::Adapters::ActiveRecord::Base#search with scopes chains scopes
rspec ./spec/ransack/adapters/active_record/base_spec.rb:90 # Ransack::Adapters::ActiveRecord::Base#search with scopes with sanitize_custom_scope_booleans set to false passes true values to scopes
rspec ./spec/ransack/adapters/active_record/base_spec.rb:95 # Ransack::Adapters::ActiveRecord::Base#search with scopes with sanitize_custom_scope_booleans set to false passes false values to scopes
rspec ./spec/ransack/adapters/active_record/base_spec.rb:108 # Ransack::Adapters::ActiveRecord::Base#search with scopes with ransackable_scopes_skip_sanitize_args enabled for scope passes true values to scopes
rspec ./spec/ransack/adapters/active_record/base_spec.rb:113 # Ransack::Adapters::ActiveRecord::Base#search with scopes with ransackable_scopes_skip_sanitize_args enabled for scope passes false values to scopes

Coverage report generated for RSpec to /home/yahonda/src/github.com/activerecord-hackery/ransack/coverage. 1819 / 1878 LOC (96.86%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
$
```