### PR TITLE
Bump Rails version to 6.1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.3
+          - v6.1.4
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.3
+          - v6.1.4
           - v6.0.3
           - 6-0-stable
           - 5-2-stable
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v6.1.3
+          - v6.1.4
           - v6.0.3
           - 6-0-stable
           - 5-2-stable


### PR DESCRIPTION
- Rails 6.1.4 has been released
https://weblog.rubyonrails.org/2021/6/24/Rails-6-1-4-has-been-released/