### PR TITLE
Fixing non-casted array predicates. Resolves issue #1245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Drop support for rubies under 2.5. PR #1189
 
+* Have casted array predicates type checked to Arel::Nodes::Casted fixing non-casted array predicates.
+  PR [1246](https://github.com/activerecord-hackery/ransack/pull/1246)
+
 ## 2.4.1 - 2020-12-21
 
 * Add `ActiveRecord::Base.ransack!` which raises error if passed unknown condition

--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -47,18 +47,19 @@ module Ransack
         end
 
         def casted_array?(predicate)
-          (predicate.respond_to?(:value) && predicate.value.is_a?(Array)) || # Rails 6.1
-            (predicate.respond_to?(:val) && predicate.val.is_a?(Array)) # Rails 5.2, 6.0
+          value_from(predicate).is_a?(Array) && predicate.is_a?(Arel::Nodes::Casted)
+        end
+
+        def value_from(predicate)
+          if predicate.respond_to?(:value)
+            predicate.value # Rails 6.1
+          elsif predicate.respond_to?(:val)
+            predicate.val # Rails 5.2, 6.0
+          end
         end
 
         def format_values_for(predicate)
-          value = if predicate.respond_to?(:value)
-                    predicate.value # Rails 6.1
-                  else
-                    predicate.val # Rails 5.2, 6.0
-                  end
-
-          value.map do |val|
+          value_from(predicate).map do |val|
             val.is_a?(String) ? Arel::Nodes.build_quoted(val) : val
           end
         end

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 module Ransack
   module Nodes
     describe Condition do
+      context 'bug report #1245' do
+        it 'preserves tuple behavior' do
+          ransack_hash = {
+              m: 'and',
+              g: [
+                { title_type_in: ['["title 1", ""]'] }
+              ]
+            }
+
+          sql = Article.ransack(ransack_hash).result.to_sql
+          expect(sql).to include("IN (('title 1', ''))")
+        end
+      end
 
       context 'with an alias' do
         subject {

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -138,6 +138,29 @@ class Article < ActiveRecord::Base
   alias_attribute :content, :body
 
   default_scope { where("'default_scope' = 'default_scope'") }
+
+  ransacker :title_type, formatter: lambda { |tuples|
+    title, type = JSON.parse(tuples)
+    Arel::Nodes::Grouping.new(
+      [
+        Arel::Nodes.build_quoted(title),
+        Arel::Nodes.build_quoted(type)
+      ]
+    )
+  } do |_parent|
+    articles = Article.arel_table
+    Arel::Nodes::Grouping.new(
+      %i[title type].map do |field|
+        Arel::Nodes::NamedFunction.new(
+          'COALESCE',
+          [
+            Arel::Nodes::NamedFunction.new('TRIM', [articles[field]]),
+            Arel::Nodes.build_quoted('')
+          ]
+        )
+      end
+    )
+  end
 end
 
 class StoryArticle < Article


### PR DESCRIPTION
Have casted array predicates type checked to Arel::Nodes::Casted fixing non-casted array predicates.