### PR TITLE
Remove part of the README that might lead to incorrect results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ this example, with preloading each Person's Articles and pagination):
 def index
   @q = Person.ransack(params[:q])
   @people = @q.result.includes(:articles).page(params[:page])
-
-  # or use `to_a.uniq` to remove duplicates (can also be done in the view):
-  @people = @q.result.includes(:articles).page(params[:page]).to_a.uniq
 end
 ```
 


### PR DESCRIPTION
It is not an actual issue with ransack itself, but I'm finding calling `to_a.uniq` on paginated active record collection misleading, it also can give incoherent results. 

if provided README example `@q.result.includes(:articles).page(params[:page]` returns a collection with duplicated results, then calling `to_a.uniq` will reduce a number of returned records, that means that the page offset will no longer be correct. 

**Steps to reproduce:**

1. Create two Person records in database
2. Create 10 articles containing word "dog" and assign it to the first Person
3. Create 1 article containing word "dog" and assign it to the second Person
4. Perform a paginated search for all Person records that wrote an article containing "dog" word, you would like to fetch first 10 records of 1st page.

**Current Result** Only one Person record is returned on 1st page and 2nd Person record is returned on second page
**Expected Result** List of two Person records is returned on the 1st page and no Person records are returned on second page.

I provided a test repo illustrating the following issue https://github.com/RadekMolenda/to_a_uniq_case

Paginated search results that rely on `LIMIT` and `OFFSET` resolved on the database level is industry standard in most of production setups that are using relational databases. Removing `to_a.uniq` section from README makes sense for me because it could be confusing for less experienced developers to understand why in some cases query results are not returning correct number of records.


