### PR TITLE
CI against Rails 7.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.0.0
           - v6.1.4
           - v6.0.4
           - 6-0-stable
@@ -21,6 +22,8 @@ jobs:
           - 2.7.4
           - 2.6.7
         exclude:
+          - rails:  v7.0.0
+            ruby:   2.6.7
           - rails:  v5.2.4
             ruby:   3.0.2
           - rails:  5-2-stable
@@ -45,6 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.0.0
           - v6.1.4
           - v6.0.4
           - 6-0-stable
@@ -55,6 +59,8 @@ jobs:
           - 2.7.4
           - 2.6.7
         exclude:
+          - rails:  v7.0.0
+            ruby:   2.6.7
           - rails:  v5.2.4
             ruby:   3.0.2
           - rails:  5-2-stable
@@ -88,6 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.0.0
           - v6.1.4
           - v6.0.4
           - 6-0-stable
@@ -98,6 +105,8 @@ jobs:
           - 2.7.4
           - 2.6.7
         exclude:
+          - rails:  v7.0.0
+            ruby:   2.6.7
           - rails:  v5.2.4
             ruby:   3.0.2
           - rails:  5-2-stable


### PR DESCRIPTION
This pull request adds CI against Rails 7.0.0 which has been released on Dec 15, 2021.

https://rubyonrails.org/2021/12/15/Rails-7-fulfilling-a-vision


Rails 7 requires Ruby 2.7.0 or higher.  Then excluded matrix for Ruby 2.6.
Refer: https://github.com/rails/rails/blob/984c3ef2775781d47efa9f541ce570daa2434a80/rails.gemspec#L12
