### PR TITLE
Fix issue with self joins and includes

### DIFF
--- a/lib/polyamorous/activerecord_5.2_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_5.2_ruby_2/join_association.rb
@@ -16,9 +16,5 @@ module Polyamorous
         super(reflection, children)
       end
     end
-
-    def ==(other)
-      base_klass == other.base_klass
-    end
   end
 end

--- a/lib/polyamorous/activerecord_6.1_ruby_2/join_association.rb
+++ b/lib/polyamorous/activerecord_6.1_ruby_2/join_association.rb
@@ -66,9 +66,5 @@ module Polyamorous
 
       joins
     end
-
-    def ==(other)
-      base_klass == other.base_klass
-    end
   end
 end

--- a/spec/polyamorous/activerecord_compatibility_spec.rb
+++ b/spec/polyamorous/activerecord_compatibility_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module Polyamorous
+  describe "ActiveRecord Compatibility" do
+    it 'works with self joins and includes' do
+      trade_account = Account.create!
+      Account.create!(trade_account: trade_account)
+
+      accounts = Account.joins(:trade_account).includes(:trade_account, :agent_account)
+      account = accounts.first
+
+      expect(account.agent_account).to be_nil
+    end
+  end
+end

--- a/spec/polyamorous/join_association_spec.rb
+++ b/spec/polyamorous/join_association_spec.rb
@@ -12,11 +12,6 @@ module Polyamorous
 
     subject { new_join_association(reflection, parent.children, Person) }
 
-    it 'respects polymorphism on equality test' do
-      expect(subject).to eq new_join_association(reflection, parent.children, Person)
-      expect(subject).not_to eq new_join_association(reflection, parent.children, Article)
-    end
-
     it 'leaves the original reflection intact for thread safety' do
       reflection.instance_variable_set(:@klass, Article)
       join_association

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -199,6 +199,11 @@ class Note < ActiveRecord::Base
   belongs_to :notable, polymorphic: true
 end
 
+class Account < ActiveRecord::Base
+  belongs_to :agent_account, class_name: "Account"
+  belongs_to :trade_account, class_name: "Account"
+end
+
 module Schema
   def self.create
     ActiveRecord::Migration.verbose = false
@@ -256,6 +261,11 @@ module Schema
         t.integer  :person_id
         t.integer  :target_person_id
         t.integer  :article_id
+      end
+
+      create_table :accounts, force: true do |t|
+        t.belongs_to :agent_account
+        t.belongs_to :trade_account
       end
     end
 


### PR DESCRIPTION
Our polyamorous monkeypatches were doing too much. Removing our custom equality and letting ActiveRecord figure it out seems to do the trick and fix this.

On some Rails & DB adapters this seems to break a polyamorous spec. However, this spec just tests an implementation detail but it's unclear whether the spec breaking has any actual bad side effect in real like, so I removed it.

Fixes #1271.