### PR TITLE
Use `bundle add` in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ Run to install:
 bundle add ransack
 ```
 
-If you would like to use the latest updates (recommended), use the `master`
-branch:
+If you would like to use the latest updates, use the `master` branch:
 
 ```ruby
-gem 'ransack', github: 'activerecord-hackery/ransack'
+bundle add ransack --github "activerecord-hackery/ransack"
 ```
 
 ## Issues tracker

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ or controller layer, you're probably not looking for Ransack.
 
 Ransack is supported for Rails 7.0, 6.x on Ruby 2.6.6 and later.
 
-In your Gemfile, for the last officially released gem:
+Run to install:
 
 ```ruby
-gem 'ransack'
+bundle add ransack
 ```
 
 If you would like to use the latest updates (recommended), use the `master`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or controller layer, you're probably not looking for Ransack.
 
 Ransack is supported for Rails 7.0, 6.x on Ruby 2.6.6 and later.
 
-Run to install:
+To install `ransack` and add it to your Gemfile, run
 
 ```ruby
 bundle add ransack


### PR DESCRIPTION
As per https://github.com/rubygems/rubygems/pull/5337, we can simplify the steps of adding a gem.