### PR TITLE
Fix `:class` option to `sort_link` when no additional parameters are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Fix `:class` option to `sort_link` not being passed to the generated link
+  correctly when no additional options are passed. For example:
+
+  ```ruby
+  sort_link(@q, :bussiness_name, class: "foo")
+  ```
+
 ## 2.6.0 - 2022-03-08
 
 * Fix regression when joining a table with itself.

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -130,7 +130,7 @@ module Ransack
 
         def url_options
           @params.merge(
-            @options.merge(
+            @options.except(:class).merge(
               @search.context.search_key => search_and_sort_params))
         end
 

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -135,7 +135,12 @@ module Ransack
         end
 
         def html_options(args)
-          html_options = extract_options_and_mutate_args!(args)
+          if args.empty?
+            html_options = @options
+          else
+            html_options = extract_options_and_mutate_args!(args)
+          end
+
           html_options.merge(
             class: [['sort_link'.freeze, @current_dir], html_options[:class]]
                    .compact.join(' '.freeze)

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -726,6 +726,30 @@ module Ransack
         it { should match /Block label&nbsp;&#9660;/ }
       end
 
+      describe '#sort_link with class option' do
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.ransack(sorts: ['name desc'])],
+            :name,
+            class: 'people', controller: 'people'
+          )
+        }
+        it { should match /class="sort_link desc people"/ }
+      end
+
+      describe '#sort_link with class option workaround' do
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.ransack(sorts: ['name desc'])],
+            :name,
+            'name',
+            { controller: 'people' },
+            class: 'people'
+          )
+        }
+        it { should match /class="sort_link desc people"/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context
           .search_form_for(Person.ransack) {} }

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -735,6 +735,7 @@ module Ransack
           )
         }
         it { should match /class="sort_link desc people"/ }
+        it { should_not match /people\?class=people/ }
       end
 
       describe '#sort_link with class option workaround' do
@@ -748,6 +749,7 @@ module Ransack
           )
         }
         it { should match /class="sort_link desc people"/ }
+        it { should_not match /people\?class=people/ }
       end
 
       describe '#search_form_for with default format' do


### PR DESCRIPTION
In the end I decided to make this fix backwards compatible.

I will deprecate passing two different option hashes in a separate PR.

Fixes #1277.