### PR TITLE
Deprecate passing two trailing hashes to `sort_link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Deprecate passing two trailing hashes to `sort_link`, for example:
+
+  ```ruby
+  sort_link(@q, :bussiness_name, "bussines_name", {}, class: "foo")
+  ```
+
+  Pass a single hash with all options instead.
+
 * Fix `:class` option to `sort_link` not being passed to the generated link
   correctly when no additional options are passed. For example:
 

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -138,6 +138,9 @@ module Ransack
           if args.empty?
             html_options = @options
           else
+            deprecation_message = "Passing two trailing hashes to `sort_link` is deprecated, merge the trailing hashes into a single one."
+            caller_location = caller_locations(2, 2).first
+            warn "#{deprecation_message} (called at #{caller_location.path}:#{caller_location.lineno})"
             html_options = extract_options_and_mutate_args!(args)
           end
 

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -739,17 +739,23 @@ module Ransack
       end
 
       describe '#sort_link with class option workaround' do
-        subject { @controller.view_context
-          .sort_link(
-            [:main_app, Person.ransack(sorts: ['name desc'])],
-            :name,
-            'name',
-            { controller: 'people' },
-            class: 'people'
-          )
-        }
-        it { should match /class="sort_link desc people"/ }
-        it { should_not match /people\?class=people/ }
+        it "generates a correct link and prints a deprecation" do
+          expect do
+            link = @controller.view_context
+              .sort_link(
+                [:main_app, Person.ransack(sorts: ['name desc'])],
+                :name,
+                'name',
+                { controller: 'people' },
+                class: 'people'
+              )
+
+            expect(link).to match(/class="sort_link desc people"/)
+            expect(link).not_to match(/people\?class=people/)
+          end.to output(
+            /Passing two trailing hashes to `sort_link` is deprecated, merge the trailing hashes into a single one\. \(called at #{Regexp.escape(__FILE__)}:/
+          ).to_stderr
+        end
       end
 
       describe '#search_form_for with default format' do


### PR DESCRIPTION
Pass a single options hash instead.