### PR TITLE
Add list of wiki contributors

### DIFF
--- a/docs/docs/going-further/wiki-contributors.md
+++ b/docs/docs/going-further/wiki-contributors.md
@@ -1,0 +1,82 @@
+---
+title: Wiki Contributors
+sidebar_position: 12
+---
+
+Ransack previously had documentation contained in a GitHub Wiki, and this content has been merged into this documentation website. The following long list of _amazing_ people all made contributions to the Wiki:
+
+* Abinoam P. Marques Jr
+* Alex Stophel
+* Andrea Schiavini
+* Andrew Vit
+* Ben Koshy
+* Brainkurv
+* Brandan Lennox
+* Brendon Muir
+* Chris Salzberg
+* Colleen McGuckin
+* David Aldridge
+* Davidson Mohanty
+* Denis Tataurov
+* Drew Moore
+* Eike Send
+* Feodor Cherashev
+* Glauco Custódio
+* Grey Baker
+* Harold.Luo
+* Herman Singh
+* Ian Smith
+* Jake Haber
+* Jan Klimo
+* Jared Beck
+* Jon Atack
+* Juanito Fatas
+* JungaJk
+* Leo Chen
+* Leon Miller-Out
+* Luca F
+* Marc Poris
+* Matt Oakley
+* Michael Kopchick
+* Nathan Colgate
+* Nguyen Phi Viet(Sun*)
+* Nguyễn Đức Long
+* NielsKSchjoedt
+* Patrick Copeland
+* Pedro Chambino
+* Rene Hopf
+* Richa Arora
+* Rob Jones
+* Roman Sokhan
+* Ryan Bates
+* Ryan Bigg
+* Sean
+* Sean Linsley
+* Sergey
+* Sunny Ripert
+* Tanbir Hasan
+* ThuyNguyen97
+* Vanda
+* Yana Agun Siswanto
+* bonyiii
+* charly
+* chifung7
+* colorfulberry
+* ddonahue99
+* ernie
+* gaaady
+* gingerlime
+* grumpit
+* itsalongstory
+* jonatack
+* kogre
+* nguyentrungson97
+* nslocum
+* omitter
+* radar
+* rilian
+* terraplane
+* tyronewilson
+* vansy61
+* willnet
+* wzcolon


### PR DESCRIPTION
Extract a list of all contributors from the old Ransack wiki.

Part of https://github.com/activerecord-hackery/ransack/issues/1295