### PR TITLE
Don't pass `data` attribute appended to query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix `:data` option to `sort_link` being incorrectly appended to the generated
+  link query parameters.
+  PR [1301](https://github.com/activerecord-hackery/ransack/pull/1301)
+
 ## 3.0.0 - 2022-03-30
 
 * Move documentation into Docusaurus.

--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -130,7 +130,7 @@ module Ransack
 
         def url_options
           @params.merge(
-            @options.except(:class).merge(
+            @options.except(:class, :data).merge(
               @search.context.search_key => search_and_sort_params))
         end
 

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -758,6 +758,18 @@ module Ransack
         end
       end
 
+      describe '#sort_link with data option' do
+        subject { @controller.view_context
+          .sort_link(
+            [:main_app, Person.ransack(sorts: ['name desc'])],
+            :name,
+            data: { turbo_action: :advance }, controller: 'people'
+          )
+        }
+        it { should match /data-turbo-action="advance"/ }
+        it { should_not match /people\?data%5Bturbo_action%5D=advance/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context
           .search_form_for(Person.ransack) {} }


### PR DESCRIPTION
Fixes https://github.com/activerecord-hackery/ransack/pull/1289#issuecomment-1084225840.

@dmitrue Can you verify whether this fixes your issue?