### PR TITLE
Tidy up CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.0
-          - v6.1.4
+          - v7.0.2
+          - v6.1.5
           - v6.0.4
-          - 6-0-stable
         ruby:
+          - 3.1.1
           - 3.0.2
           - 2.7.4
     env:
@@ -38,11 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.0
-          - v6.1.4
+          - v7.0.2
+          - v6.1.5
           - v6.0.4
-          - 6-0-stable
         ruby:
+          - 3.1.1
           - 3.0.2
           - 2.7.4
     env:
@@ -74,11 +74,11 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.0
-          - v6.1.4
+          - v7.0.2
+          - v6.1.5
           - v6.0.4
-          - 6-0-stable
         ruby:
+          - 3.1.1
           - 3.0.2
           - 2.7.4
     env:
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.2
+          ruby-version: 3.1.1
       - name: Install dependencies
         run: bundle install
       - name: Run bug report templates


### PR DESCRIPTION
This pull request updates CI as follows.

* Update Rails version to the latest Rails 7.0.2, 6.1.5
* Remove CI against 6-0-stable branch because Rails 6.0.z only accepts severe security issues
* Add Ruby 3.1.1, removed Ruby 2.6.7 from CI