### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,6 @@ jobs:
         ruby:
           - 3.0.2
           - 2.7.4
-          - 2.6.7
-        exclude:
-          - rails:  v7.0.0
-            ruby:   2.6.7
     env:
       DB: sqlite3
       RAILS: ${{ matrix.rails }}
@@ -49,10 +45,6 @@ jobs:
         ruby:
           - 3.0.2
           - 2.7.4
-          - 2.6.7
-        exclude:
-          - rails:  v7.0.0
-            ruby:   2.6.7
     env:
       DB: mysql
       RAILS: ${{ matrix.rails }}
@@ -89,10 +81,6 @@ jobs:
         ruby:
           - 3.0.2
           - 2.7.4
-          - 2.6.7
-        exclude:
-          - rails:  v7.0.0
-            ruby:   2.6.7
     env:
       DB: postgres
       RAILS: ${{ matrix.rails }}

--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/activerecord-hackery/ransack"
   s.summary     = %q{Object-based searching for Active Record.}
   s.description = %q{Ransack is the successor to the MetaSearch gem. It improves and expands upon MetaSearch's functionality, but does not have a 100%-compatible API.}
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.7'
   s.license     = 'MIT'
 
   s.add_dependency 'activerecord', '>= 6.0.4'


### PR DESCRIPTION
Ruby 2.6 has ended on March 2022
https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/

