### PR TITLE
Bump Rails and Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.2
-          - v6.1.5
+          - v7.0.3
+          - v6.1.6
         ruby:
-          - 3.1.1
-          - 3.0.2
-          - 2.7.4
+          - 3.1.2
+          - 3.0.4
+          - 2.7.6
     env:
       DB: sqlite3
       RAILS: ${{ matrix.rails }}
@@ -37,12 +37,12 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.2
-          - v6.1.5
+          - v7.0.3
+          - v6.1.6
         ruby:
-          - 3.1.1
-          - 3.0.2
-          - 2.7.4
+          - 3.1.2
+          - 3.0.4
+          - 2.7.6
     env:
       DB: mysql
       RAILS: ${{ matrix.rails }}
@@ -72,12 +72,12 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.0.2
-          - v6.1.5
+          - v7.0.3
+          - v6.1.6
         ruby:
-          - 3.1.1
-          - 3.0.2
-          - 2.7.4
+          - 3.1.2
+          - 3.0.4
+          - 2.7.6
     env:
       DB: postgres
       RAILS: ${{ matrix.rails }}
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.1
+          ruby-version: 3.1.2
       - name: Install dependencies
         run: bundle install
       - name: Run bug report templates


### PR DESCRIPTION
This pull request bumps Rails and Ruby versions.

- Rails 7.0.3, 6.1.6, 6.0.5, and 5.2.8 have been released!
https://rubyonrails.org/2022/5/9/Rails-7-0-3-6-1-6-6-0-5-and-5-2-8-have-been-released

- Ruby 3.1.2 Released
https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/

- Ruby 3.0.4 Released
https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-0-4-released/

- Ruby 2.7.6 Released
https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/