### PR TITLE
Added support of ruby and erb syntax highlightings

### DIFF
--- a/docs/docs/getting-started/simple-mode.md
+++ b/docs/docs/getting-started/simple-mode.md
@@ -11,7 +11,7 @@ mode should meet your needs.
 
 ## In your controller
 
-```jsx
+```ruby
 def index
   @q = Person.ransack(params[:q])
   @people = @q.result(distinct: true)
@@ -20,7 +20,7 @@ end
 or without `distinct: true`, for sorting on an associated table's columns (in
 this example, with preloading each Person's Articles and pagination):
 
-```jsx
+```ruby
 def index
   @q = Person.ransack(params[:q])
   @people = @q.result.includes(:articles).page(params[:page])
@@ -35,7 +35,8 @@ Ransack uses a default `:q` param key for search params. This may be changed by
 setting the `search_key` option in a Ransack initializer file (typically
 `config/initializers/ransack.rb`):
 
-```jsx
+```ruby
+puts "Hello, World"
 Ransack.configure do |c|
   # Change default search parameter key name.
   # Default key name is :q
@@ -48,7 +49,7 @@ end
 After version 2.4.0 when searching a string query Ransack by default strips all whitespace around the query string.
 This may be disabled by setting the `strip_whitespace` option in a Ransack initializer file:
 
-```jsx
+```ruby
 Ransack.configure do |c|
   # Change whitespace stripping behaviour.
   # Default is true
@@ -66,7 +67,7 @@ which are defined in
 
 Ransack's `search_form_for` helper replaces `form_for` for creating the view search form
 
-```jsx
+```erb
 <%= search_form_for @q do |f| %>
 
   # Search if the name field contains...
@@ -95,7 +96,7 @@ search predicates.
 
 The `search_form_for` answer format can be set like this:
 
-```jsx
+```erb
 <%= search_form_for(@q, format: :pdf) do |f| %>
 
 <%= search_form_for(@q, format: :json) do |f| %>
@@ -105,7 +106,7 @@ The `search_form_for` answer format can be set like this:
 
 Ransack's `sort_link` helper creates table headers that are sortable links
 
-```jsx
+```erb
 <%= sort_link(@q, :name) %>
 ```
 Additional options can be passed after the column parameter, like a different
@@ -114,13 +115,13 @@ column title or a default sort order.
 If the first option after the column parameter is a String, it's considered a
 custom label for the link:
 
-```jsx
+```erb
 <%= sort_link(@q, :name, 'Last Name', default_order: :desc) %>
 ```
 
 You can use a block if the link markup is hard to fit into the label parameter:
 
-```jsx
+```erb
 <%= sort_link(@q, :name) do %>
   <strong>Player Name</strong>
 <% end %>
@@ -130,14 +131,14 @@ With a polymorphic association, you may need to specify the name of the link
 explicitly to avoid an `uninitialized constant Model::Xxxable` error (see issue
 [#421](https://github.com/activerecord-hackery/ransack/issues/421)):
 
-```jsx
+```erb
 <%= sort_link(@q, :xxxable_of_Ymodel_type_some_attribute, 'Attribute Name') %>
 ```
 
 If the first option after the column parameter and/or the label parameter is an
 Array, it will be used for sorting on multiple fields:
 
-```jsx
+```erb
 <%= sort_link(@q, :last_name, [:last_name, 'first_name asc'], 'Last Name') %>
 ```
 
@@ -148,7 +149,7 @@ Ransack to _always_ sort that particular field in the specified direction.
 Multiple `default_order` fields may also be specified with a trailing options
 Hash:
 
-```jsx
+```erb
 <%= sort_link(@q, :last_name, %i(last_name first_name),
   default_order: { last_name: 'asc', first_name: 'desc' }) %>
 ```
@@ -162,7 +163,7 @@ of a SQL function, you may do so using scopes. In your model, define scopes
 whose names line up with the name of the virtual field you wish to sort by,
 as so:
 
-```jsx
+```ruby
 class Person < ActiveRecord::Base
   scope :sort_by_reverse_name_asc, lambda { order("REVERSE(name) ASC") }
   scope :sort_by_reverse_name_desc, lambda { order("REVERSE(name) DESC") }
@@ -171,7 +172,7 @@ class Person < ActiveRecord::Base
 
 and you can then sort by this virtual field:
 
-```jsx
+```erb
 <%= sort_link(@q, :reverse_name) %>
 ```
 
@@ -186,7 +187,7 @@ You can also enable a `default_arrow` which is displayed on all sortable fields
 which are not currently used in the sorting. This is disabled by default so
 nothing will be displayed:
 
-```jsx
+```ruby
 Ransack.configure do |c|
   c.custom_arrows = {
     up_arrow: '<i class="custom-up-arrow-icon"></i>',
@@ -200,7 +201,7 @@ All sort links may be displayed without the order indicator
 arrows by setting `hide_sort_order_indicators` to true in the initializer file.
 Note that this hides the arrows even if they were customized:
 
-```jsx
+```ruby
 Ransack.configure do |c|
   c.hide_sort_order_indicators = true
 end
@@ -209,7 +210,7 @@ end
 Without setting it globally, individual sort links may be displayed without
 the order indicator arrow by passing `hide_indicator: true` in the sort link:
 
-```jsx
+```erb
 <%= sort_link(@q, :name, hide_indicator: true) %>
 ```
 
@@ -219,15 +220,15 @@ Ransack's `sort_url` helper is like a `sort_link` but returns only the url
 
 `sort_url` has the same API as `sort_link`:
 
-```jsx
+```erb
 <%= sort_url(@q, :name, default_order: :desc) %>
 ```
 
-```jsx
+```erb
 <%= sort_url(@q, :last_name, [:last_name, 'first_name asc']) %>
 ```
 
-```jsx
+```erb
 <%= sort_url(@q, :last_name, %i(last_name first_name),
   default_order: { last_name: 'asc', first_name: 'desc' }) %>
 ```
@@ -238,7 +239,7 @@ The `NULLS FIRST` and `NULLS LAST` options can be used to determine whether null
 
 You may want to configure it like this:
 
-```jsx
+```ruby
 Ransack.configure do |c|
   c.postgres_fields_sort_option = :nulls_first # or :nulls_last
 end
@@ -246,7 +247,7 @@ end
 
 To treat nulls as having the lowest or highest value respectively. To force nulls to always be first or last, use
 
-```jsx
+```ruby
 Ransack.configure do |c|
   c.postgres_fields_sort_option = :nulls_always_first # or :nulls_always_last
 end
@@ -258,7 +259,7 @@ See this feature: https://www.postgresql.org/docs/13/queries-order.html
 
 In order to request PostgreSQL to do a case insensitive sort for all string columns of a model at once, Ransack can be extended by using this approach:
 
-```jsx
+```ruby
 module RansackObject
 
   def self.included(base)
@@ -273,7 +274,7 @@ module RansackObject
 end
 ```
 
-```jsx
+```ruby
 class UserWithManyAttributes < ActiveRecord::Base
   include RansackObject
 end

--- a/docs/docs/getting-started/simple-mode.md
+++ b/docs/docs/getting-started/simple-mode.md
@@ -36,7 +36,6 @@ setting the `search_key` option in a Ransack initializer file (typically
 `config/initializers/ransack.rb`):
 
 ```ruby
-puts "Hello, World"
 Ransack.configure do |c|
   # Change default search parameter key name.
   # Default key name is :q

--- a/docs/docs/getting-started/sorting.md
+++ b/docs/docs/getting-started/sorting.md
@@ -9,7 +9,7 @@ title: Sorting
 
 You can add a form to capture sorting and filtering options together.
 
-```jsx
+```erb
 <div class="filters" id="filtersSidebar">
   <header class="filters-header">
     <div class="filters-header-content">

--- a/docs/docs/going-further/acts-as-taggable-on.md
+++ b/docs/docs/going-further/acts-as-taggable-on.md
@@ -14,7 +14,7 @@ chances are you might want to search on tagged fields. Follow the instructions t
 
 You can call the tagging field anything you like, it just needs to be plural. No migration is needed as this is stored in the internal ActsAsTaggable tables (`tags` and `taggings`).
 
-```rb
+```ruby
 class Task < ApplicationRecord
   acts_as_taggable_on :projects
 end
@@ -26,7 +26,7 @@ Add a field to strong params in the controller. Use the singular name with `_lis
 
 `app/controllers/tasks_controller.rb`
 
-```rb
+```ruby
 def strong_params
   params
     .require(:tasks)
@@ -37,7 +37,7 @@ def strong_params
 
 We need to `send` the tag fieldname to our model, also using the singular naming.
 
-```
+```erb
 <div class='form-group'>
   <%= f.label :project_list %>
   <%= f.text_field :project_list, value: @task.send(:project_list).to_s %>
@@ -50,7 +50,7 @@ Now we can collect our data via the form, with tags separated by commas.
 
 Imagine you have the following two instances of `Task`:
 
-```rb
+```ruby
 { id: 1, name: 'Clean up my room',        projects: [ 'Home', 'Personal' ] }
 { id: 2, name: 'Complete math exercises', projects: [ 'Homework', 'Study' ] }
 ```
@@ -97,7 +97,7 @@ In Option D we allow the user to select a list of valid tags and then search aga
 
 ActsAsTaggableOn allows scoping of tags based on another field on the model. Suppose we have a `language` field on the model, as an effective second level key. We would adjust our model to look like this:
 
-```rb
+```ruby
 class Task < ApplicationRecord
   acts_as_taggable_on :projects
   acts_as_taggable_tenant :language
@@ -106,7 +106,7 @@ end
 
 The Ransack search is then filtered using the `for_tenant` method
 
-```
+```erb
 <div class='form-group'>
   <%= f.label :projects_name, 'Project' %>
   <%= f.select :projects_name_in, ActsAsTaggableOn::Tag.for_tenant('fr').distinct.order(:name).pluck(:name) %>

--- a/docs/docs/going-further/exporting-to-csv.md
+++ b/docs/docs/going-further/exporting-to-csv.md
@@ -7,7 +7,7 @@ Exporting to CSV
 
 Example downloading a csv file preserving ransack search, based on [this gist](https://gist.github.com/pama/adff25ed1f4b796ce088ea362a08e1c5)
 
-```jsx title='index.html.erb'
+```ruby title='index.html.erb'
 <h1>Users</h1>
 
 <%= search_form_for @q, url: dashboard_index_path do |f| %>
@@ -30,7 +30,7 @@ Example downloading a csv file preserving ransack search, based on [this gist](h
 <% end %>
 ```
 
-```jsx title='user.rb'
+```ruby title='user.rb'
 require 'csv'
 
 class User < ApplicationRecord

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -17,7 +17,7 @@ Ransack is supported for Rails 7.0, 6.x on Ruby 2.6.6 and later.
 
 To install `ransack` and add it to your Gemfile, run
 
-```jsx title='Gemfile'
+```ruby title='Gemfile'
 gem 'ransack'
 ```
 
@@ -25,7 +25,7 @@ gem 'ransack'
 
 If you would like to use the latest updates not yet published to RubyGems, use the `main` branch:
 
-```jsx title='Gemfile'
+```ruby title='Gemfile'
 gem 'ransack', :github => 'activerecord-hackery/ransack', :branch => 'main'
 ```
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -100,6 +100,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['ruby', 'erb'],
       },
     }),
 };


### PR DESCRIPTION
Added support `ruby` and `erb` syntax to the Prism settings. Changed `rb` key to `ruby` in code blocks. ~~Some refactor in README.~~

Fixed #1307 