### PR TITLE
Add warning about necessary authorization

### DIFF
--- a/docs/docs/getting-started/simple-mode.md
+++ b/docs/docs/getting-started/simple-mode.md
@@ -27,6 +27,10 @@ def index
 end
 ```
 
+:::caution
+By default, searching and sorting are authorized on any column of your model. See [Authorization (allowlisting/denylisting)](/going-further/other-notes.md#authorization-allowlistingdenylisting) on how to prevent this.
+:::
+
 ### Default search options
 
 #### Search parameter


### PR DESCRIPTION
In my opinion, docs should warn about not authorizing by default. This can cause serious problems when filtering the user model for example. One could easily extract email addresses, password hashes or other sensitive information.