### PR TITLE
Remove Polyamorous entrypoint

### DIFF
--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -1,1 +1,0 @@
-require 'polyamorous/polyamorous'


### PR DESCRIPTION
Extracted from https://github.com/activerecord-hackery/ransack/pull/1348

> I think we can hold it until you can have a look. Breaking require "polyamorous" could be considered a breaking change so I'd ship it with 4.0.0 too.

Should we make the next release 4.0.0 ? @deivid-rodriguez ?