### PR TITLE
Use built-in methods for nulls_first, nulls_last

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -44,13 +44,13 @@ module Ransack
               else
                 case Ransack.options[:postgres_fields_sort_option]
                 when :nulls_first
-                  scope_or_sort = scope_or_sort.direction == :asc ? Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST") : Arel.sql("#{scope_or_sort.to_sql} NULLS LAST")
+                  scope_or_sort = scope_or_sort.direction == :asc ? scope_or_sort.nulls_first : scope_or_sort.nulls_last
                 when :nulls_last
-                  scope_or_sort = scope_or_sort.direction == :asc ? Arel.sql("#{scope_or_sort.to_sql} NULLS LAST") : Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST")
+                  scope_or_sort = scope_or_sort.direction == :asc ? scope_or_sort.nulls_last : scope_or_sort.nulls_first
                 when :nulls_always_first
-                  scope_or_sort = Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST")
+                  scope_or_sort = scope_or_sort.nulls_first
                 when :nulls_always_last
-                  scope_or_sort = Arel.sql("#{scope_or_sort.to_sql} NULLS LAST")
+                  scope_or_sort = scope_or_sort.nulls_last
                 end
 
                 relation = relation.order(scope_or_sort)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -614,7 +614,7 @@ module Ransack
         expect(@s.result.first.id).to eq 1
       end
 
-      it "PG's sort option", if: ::ActiveRecord::Base.connection.adapter_name == "PostgreSQL" do
+      it "PG's sort option", if: ::ActiveRecord::Base.connection.adapter_name != "MySQL" do
         default = Ransack.options.clone
 
         s = Search.new(Person, s: 'name asc')
@@ -632,10 +632,13 @@ module Ransack
         s = Search.new(Person, s: 'name desc')
         expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"name\" DESC NULLS FIRST"
 
+        # sanity check that query actually works in the database
+        expect { s.result }.not_to raise_error
+
         Ransack.options = default
       end
 
-      it "PG's sort option with double name", if: ::ActiveRecord::Base.connection.adapter_name == "PostgreSQL" do
+      it "PG's sort option with double name", if: ::ActiveRecord::Base.connection.adapter_name != "MySQL" do
         default = Ransack.options.clone
 
         s = Search.new(Person, s: 'doubled_name asc')

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -614,7 +614,7 @@ module Ransack
         expect(@s.result.first.id).to eq 1
       end
 
-      it "PG's sort option", if: ::ActiveRecord::Base.connection.adapter_name != "MySQL" do
+      it "PG's sort option", if: ::ActiveRecord::Base.connection.adapter_name != "Mysql2" do
         default = Ransack.options.clone
 
         s = Search.new(Person, s: 'name asc')
@@ -638,7 +638,7 @@ module Ransack
         Ransack.options = default
       end
 
-      it "PG's sort option with double name", if: ::ActiveRecord::Base.connection.adapter_name != "MySQL" do
+      it "PG's sort option with double name", if: ::ActiveRecord::Base.connection.adapter_name != "Mysql2" do
         default = Ransack.options.clone
 
         s = Search.new(Person, s: 'doubled_name asc')


### PR DESCRIPTION
PR for #1373. PR not ready for merge - let's discuss. I didn't rename options or tests for now

**Summary**:
- Works for all databases except MySQL in Rails 7
- Works for PostgreSQL in Rails 6