### PR TITLE
Add support for default predicates

### DIFF
--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -101,6 +101,19 @@ module Ransack
       self.options[:ignore_unknown_conditions] = boolean
     end
 
+    # By default Ransack ignores empty predicates. Ransack can also fallback to
+    # a default predicate by setting it in an initializer file
+    # like `config/initializers/ransack.rb` as follows:
+    #
+    # Ransack.configure do |config|
+    #   # Use the 'eq' predicate if an unknown predicate is passed
+    #   config.default_predicate = 'eq'
+    # end
+    #
+    def default_predicate=(name)
+      self.options[:default_predicate] = name
+    end
+
     # By default, Ransack displays sort order indicator arrows with HTML codes:
     #
     #   up_arrow:   '&#9660;'

--- a/lib/ransack/predicate.rb
+++ b/lib/ransack/predicate.rb
@@ -10,7 +10,7 @@ module Ransack
       end
 
       def named(name)
-        Ransack.predicates[name.to_s]
+        Ransack.predicates[(name || Ransack.options[:default_predicate]).to_s]
       end
 
       def detect_and_strip_from_string!(str)

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -74,6 +74,30 @@ module Ransack
           specify { expect(subject).to be_nil }
         end
       end
+
+      context 'with an empty predicate' do
+        subject {
+          Condition.extract(
+            Context.for(Person), 'full_name', Person.first.name
+          )
+        }
+
+        context "when default_predicate = nil" do
+          before do
+            Ransack.configure { |c| c.default_predicate = nil }
+          end
+
+          specify { expect(subject).to be_nil }
+        end
+
+        context "when default_predicate = 'eq'" do
+          before do
+            Ransack.configure { |c| c.default_predicate = 'eq' }
+          end
+
+          specify { expect(subject).to eq Condition.extract(Context.for(Person), 'full_name_eq', Person.first.name) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently predicates are required, otherwise the conditions are ignored or they will raise an error.
When using Ransack for filtering in json requests, it would be nice to allow an empty predicate to equal to true.

So instead of having to explicitly pass '*_eq':

    {
      product_id_eq: 'product-1',
      type_eq:       'admin'
    }

we can do the following:

    {
      product_id: 'product-1',
      type:       'admin'
    }

This adds a `:default_predicate` configuration option that will be used in case of a missing predicate.

I'm not sure anyone would use a different default, so maybe the config option should be something like: `:default_to_eq_predicate`.