### PR TITLE
Fix required Ruby and Rails version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are advanced searching solutions around, like ElasticSearch or Algolia. **
 
 Ready to move beyond the basics? Use **advanced features** like i18n and extensive configuration options.
 
-Ransack is supported for Rails 7.0, 6.x on Ruby 2.6.6 and later.
+Ransack is supported for Rails 7.0, 6.1 on Ruby 2.7 and later.
 
 ## Installation
 


### PR DESCRIPTION
The gemspec states that the minimum required ruby version is 2.7 and the minimum required AR/AS versions are 6.1.5

This commit fixes the readme accordingly

[ci skip]