### PR TITLE
Prevent changing host through params

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -129,7 +129,7 @@ module Ransack
         end
 
         def url_options
-          @params.merge(
+          @params.except(:host).merge(
             @options.except(:class, :data, :host).merge(
               @search.context.search_key => search_and_sort_params))
         end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -808,6 +808,14 @@ module Ransack
         it { should_not match /href=".*foo/ }
       end
 
+      describe "#sort_link ignores host in params" do
+        before { @controller.view_context.params[:host] = 'other_domain' }
+        subject { @controller.view_context.sort_link(Person.ransack, :name, controller: 'people') }
+
+        it { should match /href="\/people\?q/ }
+        it { should_not match /href=".*other_domain/ }
+      end
+
       describe '#search_form_for with default format' do
         subject { @controller.view_context
           .search_form_for(Person.ransack) {} }


### PR DESCRIPTION
Currently, it is possible to change the host simply by passing a host through params. This way, visiting ```example.com/people?host=some_other_domain``` would then have sort_links with ```http://some_other_domain/people..```.