### PR TITLE
Allow nested method longhands to be passed

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -149,7 +149,7 @@ module Ransack
       def build(params)
         params.with_indifferent_access.each do |key, value|
           case key
-          when /^(g|c|m)$/
+          when /^(g|c|m|groupings|conditions|combinator)$/
             self.send("#{key}=", value)
           else
             write_attribute(key.to_s, value)


### PR DESCRIPTION
Currently we can pass either `{ g: [{ name_eq: "val" }] }` or `{ groupings: [{ name_eq: "val" }] }` to `search` and it behaves as expected. 

However if we nest these values then the **longhand** values either raise, or get ignored:

```
> Model.search({ groupings: [{ groupings: [{ name_eq: "val" }] }] })
> #<ArgumentError: No valid predicate for groupings>
```
but
```
Model.search({ groupings: [{ g: [{ name_eq: "val" }] }])
```
performs as expected.

This small change updates the regex to check for the longhand values too.