### PR TITLE
Allow nested groupings (longhand) to be passed

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -149,7 +149,7 @@ module Ransack
       def build(params)
         params.with_indifferent_access.each do |key, value|
           case key
-          when /^(g|c|m)$/
+          when /^(g|c|m|groupings|conditions|combinator)$/
             self.send("#{key}=", value)
           else
             write_attribute(key.to_s, value)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -230,7 +230,7 @@ module Ransack
         or1 = ors.first
         expect(or1).to be_a Nodes::Grouping
         expect(or1.combinator).to eq 'or'
-        expect(or1.groupings).to eq(2)
+        expect(or1.groupings.size).to eq(2)
       end
 
       it 'accepts attributes hashes for groupings' do

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -211,6 +211,28 @@ module Ransack
         expect(or2.combinator).to eq 'or'
       end
 
+      it 'accepts nested arrays of longhand :groupings' do
+        s = Search.new(Person,
+          groupings: [
+            { 
+              m: 'or', 
+              name_eq: 'Ernie', 
+              children_name_eq: 'Ernie',
+              groupings: [
+                { m: 'and', name_eq: 'Bert' },
+                { m: 'and', children_name_eq: 'Bert' }
+              ]
+            },
+          ]
+        )
+        ors = s.groupings
+        expect(ors.size).to eq(1)
+        or1 = ors.first
+        expect(or1).to be_a Nodes::Grouping
+        expect(or1.combinator).to eq 'or'
+        expect(or1.groupings).to eq(2)
+      end
+
       it 'accepts attributes hashes for groupings' do
         s = Search.new(Person,
           g: {


### PR DESCRIPTION
Currently we can pass either `{ g: [{ name_eq: "val" }] }` or `{ groupings: [{ name_eq: "val" }] }` to `search` and it behaves as expected. 

However if we nest these values then the **longhand** values either raise, or get ignored:

```
> Model.search({ groupings: [{ groupings: [{ name_eq: "val" }] }] })
> #<ArgumentError: No valid predicate for groupings>
```
but
```
Model.search({ groupings: [{ g: [{ name_eq: "val" }] }])
```
performs as expected.

This small change updates the regex to check for the longhand values too.