### PR TITLE
Fix builds for Rails 7.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.1.0.rc2
           - v7.0.3
           - v6.1.6
         ruby:
@@ -38,6 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.1.0.rc2
           - v7.0.3
           - v6.1.6
         ruby:
@@ -72,6 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - v7.1.0.rc2
           - v7.0.3
           - v6.1.6
         ruby:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.1.0.rc2
+          - v7.1.0
           - v7.0.3
           - v6.1.6
         ruby:
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.1.0.rc2
+          - v7.1.0
           - v7.0.3
           - v6.1.6
         ruby:
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - v7.1.0.rc2
+          - v7.1.0
           - v7.0.3
           - v6.1.6
         ruby:

--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -12,8 +12,9 @@ module Ransack
 
         def type_for(attr)
           return nil unless attr && attr.valid?
+          relation     = attr.arel_attribute.relation
           name         = attr.arel_attribute.name.to_s
-          table        = attr.arel_attribute.relation.table_name
+          table        = relation.respond_to?(:table_name) ? relation.table_name : relation.name
           schema_cache = self.klass.connection.schema_cache
           unless schema_cache.send(:data_source_exists?, table)
             raise "No table named #{table} exists."


### PR DESCRIPTION
Right now, Ransack fails to execute on Rails 7.1.0beta1 with the error below:

```
  1) Ransack::Search#method_missing allows chaining to access nested conditions
     Failure/Error: table        = attr.arel_attribute.relation.table_name

     NoMethodError:
       undefined method `table_name' for #<Arel::Table:...>
```

This is because the `table_name` method has been dropped as part of this commit https://github.com/rails/rails/commit/1d98bc563a8a7faf26238eaaa54a3257a95d644d, which has made Rails imcompatible with Ransack.

This PR adds a check for the existence of the `table_name` method to restore the compatibility.