### PR TITLE
Fix wrong table aliases (#1217)

### DIFF
--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -141,6 +141,22 @@ module Ransack
           end
         end
 
+        context 'has_one through associations' do
+          let(:address)  { Address.create!(city: 'Boston') }
+          let(:org) { Organization.create!(name: 'Testorg', address: address) }
+          let!(:employee) { Employee.create!(name: 'Ernie', organization: org) }
+
+          it 'works when has_one through association is first' do
+            s = Employee.ransack(address_city_eq: 'Boston', organization_name_eq: 'Testorg')
+            expect(s.result.to_a).to include(employee)
+          end
+
+          it 'works when has_one through association is last' do
+            s = Employee.ransack(organization_name_eq: 'Testorg', address_city_eq: 'Boston')
+            expect(s.result.to_a).to include(employee)
+          end
+        end
+
         context 'negative conditions on HABTM associations' do
           let(:medieval) { Tag.create!(name: 'Medieval') }
           let(:fantasy)  { Tag.create!(name: 'Fantasy') }

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -237,6 +237,20 @@ class Account < ApplicationRecord
   belongs_to :trade_account, class_name: "Account"
 end
 
+class Address < ApplicationRecord
+  has_one :organization
+end
+
+class Organization < ApplicationRecord
+  belongs_to :address
+  has_many :employees
+end
+
+class Employee < ApplicationRecord
+  belongs_to :organization
+  has_one :address, through: :organization
+end
+
 module Schema
   def self.create
     ActiveRecord::Migration.verbose = false
@@ -299,6 +313,20 @@ module Schema
       create_table :accounts, force: true do |t|
         t.belongs_to :agent_account
         t.belongs_to :trade_account
+      end
+
+      create_table :addresses, force: true do |t|
+        t.string :city
+      end
+
+      create_table :organizations, force: true do |t|
+        t.string :name
+        t.integer :address_id
+      end
+
+      create_table :employees, force: true do |t|
+        t.string :name
+        t.integer :organization_id
       end
     end
 


### PR DESCRIPTION
I encountered the same issue as reported in #1217 (and possibly in a bunch of other issues as well[^1]).

It was correctly pointed out, that a change in ActiveRecord was responsible. https://github.com/rails/rails/commit/10b36e81a357f8d7fa3665630c4d41c057fe59d9 tried to fix a bug with eager loading that resulted from aliasing a joined table that was (then incorrectly) referenced in a WHERE clause.

The solution (as far as I understand it - I never had to look at that code before and cannot say I understand all of what is going on there) was to cache tables already joined and reuse those joins if possible.

The problem in #1217 is caused by ransack prepopulating table information *before* this deduplication code is run. So there is no way to detect that a JOIN clause with an alias, that would otherwise have been used, fell victim to the deduplication.

My "solution" is a poor one. I simply copied the deduplication logic from ActiveRecord. This should give the same results as ActiveRecord would come up with on its own.

A better solution would of course be to somehow get the table information at a later point in time and/or extract the deduplication logic in AR to be able to reuse this more easily. But I suspect the first approach would take a huge refactoring of ransack and I am not 100% sure if it is even possible. Also, I am not convinced that ActiveRecord currently cleans up references to table aliases that are not being used due to the deduplication correctly. So patches for AR itself might be needed anyways.

---

[^1]: The following issues seem like they could be related: #1238, #1253, #1227, #1153, #1144