### PR TITLE
Include version const

### DIFF
--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -21,6 +21,7 @@ require 'ransack/ransacker'
 require 'ransack/translate'
 require 'ransack/active_record'
 require 'ransack/context'
+require 'ransack/version'
 
 ActiveSupport.on_load(:action_controller) do
   require 'ransack/helpers'


### PR DESCRIPTION
Include the file `version.rb` to define the `Ransack::VERSION` const.

Ransack defines a `VERSION` const, but the `version.rb` file is not included in the requires list in the gem entry code.