### PR TITLE
Remove ActionView::Helpers::Tags::Base#value Monkey Patch

### DIFF
--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -1,23 +1,5 @@
 require 'action_view'
 
-module ActionView::Helpers::Tags
-  # TODO: Find a better way to solve this issue!
-  # This patch is needed since this Rails commit:
-  # https://github.com/rails/rails/commit/c1a118a
-  class Base
-    private
-    if defined? ::ActiveRecord
-      def value
-        if @allow_method_names_outside_object
-          object.send @method_name if object && object.respond_to?(@method_name, true)
-        else
-          object.send @method_name if object
-        end
-      end
-    end
-  end
-end
-
 RANSACK_FORM_BUILDER = 'RANSACK_FORM_BUILDER'.freeze
 
 require 'simple_form' if

--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -112,6 +112,7 @@ module Ransack
 
       def predicate_select(options = {}, html_options = {})
         options[:compounds] = true if options[:compounds].nil?
+        options[:selected] ||= nil
         default = options.delete(:default) || Constants::CONT
 
         keys =


### PR DESCRIPTION
This library provides an override of `ActionView::Helpers::Tags::Base#value` (the method that is used to determine the current value of a form field built from a template object) that allows calling private methods. The implementation is otherwise the same as the one provide by ActionView.

I ran into some bizarre edge cases with this implementation when using `OpenStruct`, for example just having the `ransack` gem in memory and then using a `f.text_field :test` with an `OpenStruct` as `model` will display a confusing `wrong number of arguments, given 0 expected 2..3` message because `#test` is a private method on `Kernel`. Regardless of how I got here, I don't think this monkey patch is necessary or desired anymore.

Without looking in detail, the reason I believe this patch was created in the first place is because [here](https://github.com/activerecord-hackery/ransack/blob/4a6f9b93adb860c038b6be0c6d5972cb51ea1e70/lib/ransack/helpers/form_builder.rb#L154) we define a select tag with `:p`, and like `:test`, `:p` is a private method on `Kernel`, and creating a select tag in this way will cause the form builder to see if there is a `:p` method to fetch an existing value.

In the second commit in this PR, we can simply default `selected: nil` in `options` such that the form builder does not try to figure out what the existing value is to see if one of the values is selected.

I don't use Ransack directly much (outside of ActiveAdmin) so I can't say if that will be a breaking change, but the tests do pass after that change. Open to feedback!