### PR TITLE
Delegate alias_tracker creation to AR Relation rather than doing it ourselves

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -110,7 +110,7 @@ module Ransack
         #
         def join_sources
           base, joins = begin
-            alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, @object.table.name, [])
+            alias_tracker = @object.alias_tracker
             constraints   = @join_dependency.join_constraints(@object.joins_values, alias_tracker, @object.references_values)
 
             [
@@ -278,7 +278,7 @@ module Ransack
 
           join_list = join_nodes + convert_join_strings_to_ast(relation.table, string_joins)
 
-          alias_tracker = ::ActiveRecord::Associations::AliasTracker.create(self.klass.connection, relation.table.name, join_list)
+          alias_tracker = relation.alias_tracker(join_list)
           join_dependency = Polyamorous::JoinDependency.new(relation.klass, relation.table, association_joins, Arel::Nodes::OuterJoin)
           join_dependency.instance_variable_set(:@alias_tracker, alias_tracker)
           join_nodes.each do |join|


### PR DESCRIPTION
Closes #1491.

This PR is addressing an error we are experiencing on edge rails.  This error is caused because the API for creating an `ActiveRecord::Associations::AliasTracker` [has changed in edge rails](https://github.com/rails/rails/commit/fa048105d145536538b923fa57465bdeee559e88).  It now wants to eat a connection pool rather than a connection.  Knowing nothing about ransack's internals, from what I can tell it shouldn't need to use this API directly, and should just ask it's `ActiveRecord::Relation` to create a fresh `AliasTracker` instead.  This patch includes my naive way of doing so.  It fixes the breakages in our own test suite.  Please let me know if there are other additions I should include.
