### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/ransack.gemspec
+++ b/ransack.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |s|
   s.description = %q{Ransack is the successor to the MetaSearch gem. It improves and expands upon MetaSearch's functionality, but does not have a 100%-compatible API.}
   s.required_ruby_version = '>= 3.0'
   s.license     = 'MIT'
+  
+  s.metadata = {
+    'changelog_uri' => "#{s.homepage}/releases/tag/v#{s.version}"
+  }
 
   s.add_dependency 'activerecord', '>= 6.1.5'
   s.add_dependency 'activesupport', '>= 6.1.5'


### PR DESCRIPTION
Documented here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater

I chose the releases page because `CHANGELOG.md` is missing the newest version, 4.1.1.