### PR TITLE
Fix require of rails 7.2 join association file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rails:
           - 7-2-stable
-          - v7.1.0
+          - v7.1.3.4
           - v7.0.3
           - v6.1.6
         ruby:

--- a/lib/polyamorous/polyamorous.rb
+++ b/lib/polyamorous/polyamorous.rb
@@ -15,7 +15,7 @@ if defined?(::ActiveRecord)
   require 'polyamorous/activerecord/join_dependency'
   require 'polyamorous/activerecord/reflection'
 
-  if ::ActiveRecord.version > ::Gem::Version.new("7.1")
+  if ::ActiveRecord.version >= ::Gem::Version.new("7.2")
     require "polyamorous/activerecord/join_association_7_2"
   end
 


### PR DESCRIPTION
Don't require the file for rails > 7.1.0 but < 7.2.

Fixes #1505.