### PR TITLE
Make polyamorous/activerecord/join_association including work properly with Rails 7.1 builds

### DIFF
--- a/lib/polyamorous/polyamorous.rb
+++ b/lib/polyamorous/polyamorous.rb
@@ -15,7 +15,7 @@ if defined?(::ActiveRecord)
   require 'polyamorous/activerecord/join_dependency'
   require 'polyamorous/activerecord/reflection'
 
-  if ::ActiveRecord.version > ::Gem::Version.new("7.1")
+  if ::ActiveRecord.version >= ::Gem::Version.new("7.2")
     require "polyamorous/activerecord/join_association_7_2"
   end
 


### PR DESCRIPTION
Include code intended for Rails 7.2 only when actual Rails version is 7.2+

Currently it requires this file on Rails `7.1.1+` for example