### PR TITLE
Add support for Ransack::Nodes::Grouping#read_attribute to use aliases

### DIFF
--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -178,6 +178,13 @@ module Ransack
       end
 
       def read_attribute(name)
+        if self[name].nil?
+          stripped_name = name.dup
+          predicate = Predicate.detect_and_strip_from_string!(stripped_name)
+          aliased_attribute = context.ransackable_alias(stripped_name)
+          name = "#{aliased_attribute}_#{predicate}" unless aliased_attribute == stripped_name
+        end
+
         if self[name].respond_to?(:value)
           self[name].value
         else

--- a/spec/ransack/nodes/grouping_spec.rb
+++ b/spec/ransack/nodes/grouping_spec.rb
@@ -106,6 +106,23 @@ module Ransack
         end
       end
 
+      describe "#read_attribute" do
+          let(:conditions) do
+            {
+              '0' => {
+                'a' => { '0'=> { 'name' => 'parent_name', 'ransacker_args' => '' } },
+                'p' => 'cont',
+                'v' => { '0' => { 'value' => 'John' } }
+              },
+            }
+          end
+          before { subject.conditions = conditions }
+
+          it "works with aliases" do
+            expect(subject.parent_name_cont).to eq("John")
+            expect(subject.daddy_cont).to eq("John")
+          end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/activerecord-hackery/ransack/issues/689

This works locally in my test environment, it should be lightweight and only used if we don't have an immediately matching attribute in the context.

It's a pretty simple change but I'm not sure if there's some unforeseen consequences I'm unaware of.

I looked at the contributing guide but there's nothing about updating the changelog in the PR :) 