### PR TITLE
Fix rails 7.2 loading

### DIFF
--- a/lib/polyamorous/polyamorous.rb
+++ b/lib/polyamorous/polyamorous.rb
@@ -1,4 +1,4 @@
-if defined?(::ActiveRecord)
+ActiveSupport.on_load(:active_record) do
   module Polyamorous
     InnerJoin = Arel::Nodes::InnerJoin
     OuterJoin = Arel::Nodes::OuterJoin

--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -1,3 +1,4 @@
+require 'active_support/dependencies/autoload'
 require 'active_support/core_ext'
 require 'ransack/configuration'
 require 'polyamorous/polyamorous'

--- a/lib/ransack.rb
+++ b/lib/ransack.rb
@@ -1,4 +1,11 @@
 require 'active_support/dependencies/autoload'
+require 'active_support/deprecation'
+require 'active_support/version'
+
+if ::ActiveSupport.version >= ::Gem::Version.new("7.1")
+  require 'active_support/deprecator'
+end
+
 require 'active_support/core_ext'
 require 'ransack/configuration'
 require 'polyamorous/polyamorous'

--- a/lib/ransack/helpers/form_builder.rb
+++ b/lib/ransack/helpers/form_builder.rb
@@ -6,13 +6,12 @@ module ActionView::Helpers::Tags
   # https://github.com/rails/rails/commit/c1a118a
   class Base
     private
-    if defined? ::ActiveRecord
-      def value
-        if @allow_method_names_outside_object
-          object.send @method_name if object && object.respond_to?(@method_name, true)
-        else
-          object.send @method_name if object
-        end
+
+    def value
+      if @allow_method_names_outside_object
+        object.send @method_name if object && object.respond_to?(@method_name, true)
+      else
+        object.send @method_name if object
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,12 @@
-require 'machinist/active_record'
-require 'polyamorous/polyamorous'
+require 'ransack'
 require 'sham'
 require 'faker'
-require 'ransack'
 require 'action_controller'
 require 'ransack/helpers'
 require 'pry'
 require 'simplecov'
 require 'byebug'
+require 'machinist/active_record'
 
 SimpleCov.start
 I18n.enforce_available_locales = false


### PR DESCRIPTION
Fixes #1518 

# Problem

In a typical Rails app, the Ransack gem gets loaded before ActiveRecord gets loaded.  [Rails recommends](https://guides.rubyonrails.org/configuring.html#avoid-loading-rails-frameworks) that gems avoid loading Rails frameworks when they themselves are loaded.  Ransack accomplishes that (as far as I can tell); however, Ransack initializes certain parts of its code within blocks like

```ruby
if defined?(::ActiveRecord)
  ...set up some stuff
end
```

If Ransack is loaded before `ActiveRecord` is loaded, those blocks of code are never reached.  I think these blocks of code should be wrapped with `ActiveSupport.on_load(:active_record)` instead of `if defined?(::ActiveRecord)`.  The blocks of code should run after `ActiveRecord` is loaded, which is what `on_load(:active_record)` is meant to accomplish.

# Test coverage

I wasn't quite sure how to cover this in the specs, so I adjusted the load order in `spec/spec_helper.rb` to `require "ransack"` first.  That did expose the load order issue(s) within the gem, so maybe that is good enough.  It might be ideal to set up a test that spins up a Rails app and runs a basic query just to check that the basic functionality of the gem works within Rails 🤷‍♂️ .  For local development, I used a single file Rails app like this:

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'debug'
  gem 'irb'
  gem 'rails', '>= 7.1'
  gem 'sqlite3', '~> 1.4'
  gem 'ransack' # , path: "./ransack"
end

require 'debug'
require 'rails/all'
database = 'development.sqlite3'

ENV['DATABASE_URL'] = "sqlite3:#{database}"

class App < Rails::Application
  config.load_defaults 7.2
  config.eager_load = false
end

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: database)
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title, null: false
  end
end

App.initialize!

class Post < ActiveRecord::Base

  def self.ransackable_associations(_auth_object = nil) = []

  def self.ransackable_attributes(_auth_object = nil)
    %w[title]
  end

end

1.upto(10) { |i| Post.create!(title: "Title #{i}") }

IRB.start

Post.ransack(title_eq: "Title 1").result.to_sql
=> SELECT * FROM posts where title = 'Title 1'
``` 