### PR TITLE
Raise Ransack::InvalidSearchError instead of ArgumentError on unknown conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Rails 8 compatibility
 * Drop Rails 6 and 7.0 compatibility
+* Raise Ransack::InvalidSearchError instead of ArgumentError on unknown conditions
 
 ## 4.2.1 - 2024-8-11
 

--- a/docs/docs/going-further/other-notes.md
+++ b/docs/docs/going-further/other-notes.md
@@ -263,7 +263,7 @@ end
 
 ```ruby
 Article.ransack(unknown_attr_eq: 'Ernie')
-# ArgumentError (Invalid search term unknown_attr_eq)
+# Ransack::InvalidSearchError (Invalid search term unknown_attr_eq)
 ```
 
 As an alternative to setting a global configuration option, the `.ransack!`
@@ -271,7 +271,7 @@ class method also raises an error if passed an unknown condition:
 
 ```ruby
 Article.ransack!(unknown_attr_eq: 'Ernie')
-# ArgumentError: Invalid search term unknown_attr_eq
+# Ransack::InvalidSearchError: Invalid search term unknown_attr_eq
 ```
 
 This is equivalent to the `ignore_unknown_conditions` configuration option,

--- a/lib/ransack/invalid_search_error.rb
+++ b/lib/ransack/invalid_search_error.rb
@@ -1,0 +1,3 @@
+module Ransack
+  class InvalidSearchError < ArgumentError; end
+end

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -1,3 +1,5 @@
+require 'ransack/invalid_search_error'
+
 module Ransack
   module Nodes
     class Condition < Node
@@ -38,7 +40,7 @@ module Ransack
             predicate = Predicate.named(name)
 
             unless predicate || Ransack.options[:ignore_unknown_conditions]
-              raise ArgumentError, "No valid predicate for #{key}"
+              raise InvalidSearchError, "No valid predicate for #{key}"
             end
 
             if context.present?

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -7,6 +7,7 @@ require 'ransack/nodes/sort'
 require 'ransack/nodes/grouping'
 require 'ransack/context'
 require 'ransack/naming'
+require 'ransack/invalid_search_error'
 
 module Ransack
   class Search
@@ -53,7 +54,7 @@ module Ransack
         elsif base.attribute_method?(key)
           base.send("#{key}=", value)
         elsif !Ransack.options[:ignore_unknown_conditions] || !@ignore_unknown_conditions
-          raise ArgumentError, "Invalid search term #{key}"
+          raise InvalidSearchError, "Invalid search term #{key}"
         end
       end
       self
@@ -78,7 +79,7 @@ module Ransack
       when String
         self.sorts = [args]
       else
-        raise ArgumentError,
+        raise InvalidSearchError,
         "Invalid argument (#{args.class}) supplied to sorts="
       end
     end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -131,8 +131,12 @@ module Ransack
             expect { Person.ransack('') }.to_not raise_error
           end
 
-          it 'raises exception if ransack! called with unknown condition' do
+          it 'raises ArgumentError exception if ransack! called with unknown condition' do
             expect { Person.ransack!(unknown_attr_eq: 'Ernie') }.to raise_error(ArgumentError)
+          end
+
+          it 'raises InvalidSearchError exception if ransack! called with unknown condition' do
+            expect { Person.ransack!(unknown_attr_eq: 'Ernie') }.to raise_error(InvalidSearchError)
           end
 
           it 'does not modify the parameters' do

--- a/spec/ransack/nodes/condition_spec.rb
+++ b/spec/ransack/nodes/condition_spec.rb
@@ -64,6 +64,7 @@ module Ransack
           end
 
           specify { expect { subject }.to raise_error ArgumentError }
+          specify { expect { subject }.to raise_error InvalidSearchError }
         end
 
         context "when ignore_unknown_conditions is true" do

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -270,6 +270,7 @@ module Ransack
           end
 
           specify { expect { subject }.to raise_error ArgumentError }
+          specify { expect { subject }.to raise_error InvalidSearchError }
         end
 
         context 'when ignore_unknown_conditions configuration option is true' do
@@ -300,6 +301,7 @@ module Ransack
 
         context 'when ignore_unknown_conditions search parameter is false' do
           specify { expect { with_ignore_unknown_conditions_false }.to raise_error ArgumentError }
+          specify { expect { with_ignore_unknown_conditions_false }.to raise_error InvalidSearchError }
         end
 
         context 'when ignore_unknown_conditions search parameter is true' do
@@ -612,6 +614,18 @@ module Ransack
       it 'overrides existing sort' do
         @s.sorts = 'id asc'
         expect(@s.result.first.id).to eq 1
+      end
+
+      it 'raises ArgumentError when an invalid argument is sent' do
+        expect do
+          @s.sorts = 1234
+        end.to raise_error(ArgumentError,  "Invalid argument (Integer) supplied to sorts=")
+      end
+
+      it 'raises InvalidSearchError when an invalid argument is sent' do
+        expect do
+          @s.sorts = 1234
+        end.to raise_error(Ransack::InvalidSearchError,  "Invalid argument (Integer) supplied to sorts=")
       end
 
       it "PG's sort option", if: ::ActiveRecord::Base.connection.adapter_name == "PostgreSQL" do


### PR DESCRIPTION
# Summary
Currently, when Ransack encounters invalid search attributes (those not included in `ransackable_attributes`) while using `Model.ransack!()` it raises a generic `ArgumentError`. This makes it difficult to provide helpful feedback to an API consumer that their search params are incorrect.

This PR adds a custom exception type `Ransack::InvalidSearchError` and raises it instead of `ArgumentError` in cases where there are invalid attributes used in a search.

# ✅ Backwards compatible
The solution in this PR should be perfectly backwards compatible. The new error inherits from ArgumentError, and the test cases assert this. 

# Problem
Assume I have the following code in my controller

```ruby
def index
  # this will raise (ArgumentError:  Invalid search term frist_name)
  results = User.ransack!(frist_name_eq: 'John').result 
  render json: to_json(result)
end
```

As a result this will return 5xx to the consumer. But since this is a user error, i want to return 4xx. 

I could fix this by adding the following: 

```ruby
def index
  scope = User
  begin 
    scope = scope.ransack(frist_name_eq: 'John')
  rescue ArgumentError e
    render json: {message: e.message}, status: :bad_request
  end
  render json: to_json(scope.result)
```
but the problem is that I have to add this everywhere in my controllers. 

I could make this cleaner by having a helper, for example defining a `rescuable_ransack` method to extend active record e.g: 

```ruby
module RescuableRansackable
  class InvalidRansackSearch < StandardError;
  
  def rescuable_ransack(params)
    ransack!(params)
  rescue ArgumentError e
    raise InvalidRansackSearch, e.message
  end
end

ActiveRecord::Base.extend(RescuableRansackable)
```

then using `rescuable_ransack` in my controllers: 

```ruby
# users_controller.rb
def index
  results = User.rescuable_ransack(frist_name_eq: 'John').result
  render json: to_json(result)
end
```

then add something to my application controller to catch all such exceptions: 

```ruby
class Api::V1::ApplicationController < ApplicationController
  rescue_from InvalidRansackSearch do |e|
    render json: { error: e.message }, status: :bad_request
  end
end
```

which would work, but this also seems pretty useful to have in ransack itself. Hence this suggestion to add it to the library. 

# Proposed Solution
Add a specialized exception class (e.g., `Ransack::InvalidSearchError`) that would be raised in cases where `ignore_unknown_conditions` currently raises an `ArgumentError`. This would then allow me to add something in my ApplicationController like the following: 

```ruby
class Api::V1::ApplicationController < ApplicationController
  rescue_from Ransack::InvalidSearchError do |e|
    render json: { error: e.message }, status: :bad_request
  end
end
```

This would be a very concise way to catch and handle such problems in controller actions. 