### PR TITLE
Add blank lines after last `let` in RSpec examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+plugins:
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 3.0
 
@@ -31,6 +34,9 @@ Layout/SpaceInsideParens:
   Enabled: true
 
 Layout/TrailingEmptyLines:
+  Enabled: true
+
+RSpec/EmptyLineAfterFinalLet:
   Enabled: true
 
 Style/HashSyntax:

--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,4 @@ group :test do
 end
 
 gem 'rubocop', require: false
+gem 'rubocop-rspec', require: false

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -502,6 +502,7 @@ module Ransack
             let(:params) { ActionController::Parameters.new(
               { q: { name_eq: 'TEST' }, controller: 'people' }
               ) }
+
             before { @controller.instance_variable_set(:@params, params) }
 
             it {
@@ -517,6 +518,7 @@ module Ransack
             let(:params) { ActionController::Parameters.new(
               { q: { name_eq: 'TEST' }, controller: 'people' }
               ) }
+
             before { @controller.instance_variable_set(:@params, params) }
 
             it {
@@ -533,6 +535,7 @@ module Ransack
               ActionController::Parameters.new(
                 { 'q' => { name_eq: 'Test2' }, controller: 'people' }
                 ) }
+
             before { @controller.instance_variable_set(:@params, params) }
 
             it {
@@ -549,6 +552,7 @@ module Ransack
               ActionController::Parameters.new(
                 { 'q' => { name_eq: 'Test2' }, controller: 'people' }
                 ) }
+
             before { @controller.instance_variable_set(:@params, params) }
 
             it {

--- a/spec/ransack/nodes/grouping_spec.rb
+++ b/spec/ransack/nodes/grouping_spec.rb
@@ -66,6 +66,7 @@ module Ransack
               }
             }
           end
+
           before { subject.conditions = conditions }
 
           it 'expect duplicates to be removed' do
@@ -98,6 +99,7 @@ module Ransack
               }
             }
           end
+
           before { subject.conditions = conditions }
 
           it 'expect them to be parsed as different and not as duplicates' do

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -349,6 +349,7 @@ module Ransack
       let(:notable_type_field) {
         "#{quote_table_name("notes")}.#{quote_column_name("notable_type")}"
       }
+
       it 'evaluates conditions contextually' do
         s = Search.new(Person, children_name_eq: 'Ernie')
         expect(s.result).to be_an ActiveRecord::Relation


### PR DESCRIPTION
Extracted and extended from #1559.