### PR TITLE
Cast array input to integer node value as nil

### DIFF
--- a/lib/ransack/nodes/value.rb
+++ b/lib/ransack/nodes/value.rb
@@ -88,7 +88,7 @@ module Ransack
       end
 
       def cast_to_integer(val)
-        val.blank? ? nil : val.to_i
+        val.respond_to?(:to_i) && !val.blank? ? val.to_i : nil
       end
 
       def cast_to_float(val)

--- a/spec/ransack/nodes/value_spec.rb
+++ b/spec/ransack/nodes/value_spec.rb
@@ -71,6 +71,18 @@ module Ransack
         end
       end
 
+      [[], ["12"], ["101.5"]].each do |value|
+        context "with an array value (#{value.inspect})" do
+          let(:raw_value) { value }
+
+          it "should cast to integer as nil" do
+            result = subject.cast(:integer)
+
+            expect(result).to be nil
+          end
+        end
+      end
+
       ["12", "101.5"].each do |value|
         context "with a float value (#{value})" do
           let(:raw_value) { value }


### PR DESCRIPTION
Ensure malformed or malicious user input doesn't crash the Rails page.

Previously, when a user submits a non-empty array, it would raise the exception:

```
NoMethodError: undefined method 'to_i' for an instance of Array
```

Fixes #1556