### PR TITLE
Consolidate the v5.0.0 branch into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/activerecord-hackery/ransack/workflows/test/badge.svg)](https://github.com/activerecord-hackery/ransack/actions)
 [![Gem Version](https://badge.fury.io/rb/ransack.svg)](http://badge.fury.io/rb/ransack)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/activerecord-hackery/ransack)
 [![Code Climate](https://codeclimate.com/github/activerecord-hackery/ransack/badges/gpa.svg)](https://codeclimate.com/github/activerecord-hackery/ransack)
 [![Backers on Open Collective](https://opencollective.com/ransack/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/ransack/sponsors/badge.svg)](#sponsors)
 

--- a/docs/docs/going-further/release_process.md
+++ b/docs/docs/going-further/release_process.md
@@ -25,13 +25,13 @@ To release a new version of Ransack and publish it to RubyGems, take the followi
 
 ### Manual Release Process
 
-Example for release 4.4.0 
+Example for release 4.4.1 
 
-1. Update the [`version.rb`](https://github.com/activerecord-hackery/ransack/lib/ransack/version.rb) file to the `4.4.0`, commit and push to `main`.
+1. Update the [`version.rb`](https://github.com/activerecord-hackery/ransack/lib/ransack/version.rb) file to the `4.4.1`, commit and push to `main`.
 3. Click the [Draft a new Release](https://github.com/activerecord-hackery/ransack/releases/new) button 
 4. Use these settings:
-- Tag: v4.4.0
-- Release Title: 4.4.0
+- Tag: v4.4.1
+- Release Title: 4.4.1
 - Check `Set as the Latest Release`
 - Click `Generate release notes`
 - Click `Publish Release`
@@ -41,7 +41,7 @@ Example for release 4.4.0
 ```bash
 gem signin
 rake build
-rake release
+gem push pkg/ransack-4.4.1.gem
 ```
 
 

--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -89,6 +89,14 @@ module Ransack
       @klass.method(scope).arity
     end
 
+    def sanitize_scope_args(key, args)
+      if Ransack.options[:sanitize_scope_args] && !ransackable_scope_skip_sanitize_args?(key, object)
+        cast_scope_args(args)
+      else
+        args
+      end
+    end
+
     def bind(object, str)
       return nil unless str
       object.parent, object.attr_name = bind_pair_for(str)
@@ -185,6 +193,22 @@ module Ransack
 
     def searchable_associations(str = ''.freeze)
       traverse(str).ransackable_associations(auth_object)
+    end
+
+    private
+
+    def cast_scope_args(args)
+      if args.is_a?(Array)
+        args = args.map(&method(:cast_scope_args))
+      end
+
+      if Constants::TRUE_VALUES.include? args
+        true
+      elsif Constants::FALSE_VALUES.include? args
+        false
+      else
+        args
+      end
     end
   end
 end

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -152,7 +152,11 @@ module Ransack
           when /^(g|c|m)$/
             self.send("#{key}=", value)
           else
-            write_attribute(key.to_s, value)
+            if @context.ransackable_scope?(key, @context.object)
+              @context.chain_scope(key, @context.sanitize_scope_args(key, value))
+            else
+              write_attribute(key.to_s, value)
+            end
           end
         end
         self

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -132,11 +132,7 @@ module Ransack
     private
 
     def add_scope(key, args)
-      sanitized_args = if Ransack.options[:sanitize_scope_args] && !@context.ransackable_scope_skip_sanitize_args?(key, @context.object)
-        sanitized_scope_args(args)
-      else
-        args
-      end
+      sanitized_args = @context.sanitize_scope_args(key, args)
 
       if @context.scope_arity(key) == 1
         @scope_args[key] = args.is_a?(Array) ? args[0] : args
@@ -144,20 +140,6 @@ module Ransack
         @scope_args[key] = args.is_a?(Array) ? sanitized_args : args
       end
       @context.chain_scope(key, sanitized_args)
-    end
-
-    def sanitized_scope_args(args)
-      if args.is_a?(Array)
-        args = args.map(&method(:sanitized_scope_args))
-      end
-
-      if Constants::TRUE_VALUES.include? args
-        true
-      elsif Constants::FALSE_VALUES.include? args
-        false
-      else
-        args
-      end
     end
 
     def collapse_multiparameter_attributes!(attrs)

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -473,6 +473,31 @@ module Ransack
           expect(@s.result.to_sql).to match /#{field} NOT IN \('a', 'b'\)/
         end
       end
+
+      # Pending spec for https://github.com/activerecord-hackery/ransack/issues/1553
+      # When a custom predicate uses arel_predicate: 'in' together with a formatter
+      # that builds the inner SQL fragment manually (e.g. joining with "','"),
+      # ActiveRecord double-escapes the single quotes, producing IN ('a'',''b')
+      # instead of IN ('a', 'b').
+      #
+      # Marked pending because the fix direction needs a design call. See the
+      # discussion on the linked issue.
+      describe "with 'in' arel predicate and a string-returning formatter" do
+        before do
+          Ransack.configure do |c|
+            c.add_predicate "in_list",
+              arel_predicate: "in",
+              formatter: proc { |v| v&.split(";")&.join("','") }
+          end
+        end
+
+        it 'does not double-escape single quotes in the formatted value' do
+          pending "https://github.com/activerecord-hackery/ransack/issues/1553"
+          @s.name_in_list = "Aaron;Ernie"
+          field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+          expect(@s.result.to_sql).to match /#{field} IN \('Aaron', 'Ernie'\)/
+        end
+      end
     end
 
     private

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -444,6 +444,28 @@ module Ransack
           }.not_to raise_error
         end
       end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1339
+      # Scopes nested inside groupings (`g: [...]`) were silently dropped
+      # rather than applied to the query.
+      context "ransackable_scope inside groupings" do
+        before do
+          allow(Person).to receive(:ransackable_scopes)
+            .and_return(Person.ransackable_scopes + [:over_age])
+        end
+
+        it "applies the scope when it is the only key inside a grouping" do
+          s = Search.new(Person, g: [{ over_age: 18 }])
+          expect(s.result.to_sql).to match(/age > '?18'?/)
+        end
+
+        it "applies the scope alongside other conditions in the same grouping" do
+          s = Search.new(Person, g: [{ name_eq: 'Aaron', over_age: 18 }])
+          sql = s.result.to_sql
+          expect(sql).to match(/age > '?18'?/)
+          expect(sql).to match(/name.* = 'Aaron'/)
+        end
+      end
     end
 
     describe '#result' do


### PR DESCRIPTION
Part of #1640 (does not close it).

`v5.0.0` and `main` had diverged, and PRs were arriving against both branches. This merges the two so `main` becomes the single line of development for the 5.0.0 effort.

On `v5.0.0` but not `main`:
- Add pending spec capturing issue #1553 (#1672)
- Fix scopes inside groupings being silently dropped (#1339, #1490) (#1673)
- Add DeepWiki badge (#1643)
- Update gem release docs (#1646)

On `main` but not `v5.0.0`:
- support enum (#1665)
- Add CI with Rails 8.1 and Ruby 3.3.x, 3.4.x and 4.0.1 (#1667)
- Revise CHANGELOG for versioning and support updates (#1648)

The merge is conflict-free. Verified locally against Rails 8.1 / Ruby 3.4 on SQLite: **517 examples, 0 failures, 1 pending** (the intentionally-pending #1553 spec added in #1672).

After this lands, `v5.0.0` is fast-forwarded to match `main`, and open PRs targeting `v5.0.0` are retargeted to `main`.