### PR TITLE
Remove empty key value pairs when using advanced search hash

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -27,6 +27,14 @@ module Ransack
         params = params.dup
         params = params.transform_values { |v| v.is_a?(String) && strip_whitespace ? v.strip : v }
         params.delete_if { |k, v| [*v].all?{ |i| i.blank? && i != false } }
+        if params.key?(:c)
+          case params[:c]
+          when Array
+            params[:c].delete_if { |v| check_advanced_search_value? v }
+          when Hash
+            params[:c].delete_if { |_,v| check_advanced_search_value? v }
+          end
+        end
       else
         params = {}
       end
@@ -191,5 +199,13 @@ module Ransack
       attrs
     end
 
+    def check_advanced_search_value?(value)
+      case value[:v]
+      when Array
+        value[:v].all?{ |i| i.blank? && i != false }
+      when Hash
+        value[:v].all?{ |_,i| value[:value].blank? && value[:value] != false }
+      end
+    end
   end
 end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -362,6 +362,17 @@ module Ransack
             expect(s.result.to_sql).not_to match /LEFT OUTER JOIN/
           end
 
+          it 'should remove empty key value pairs from the complex params hash' do
+            s = Person.ransack(
+              c: {
+                '0' => {
+                        a: ['children_name'],
+                        p: 'eq', v: ['']
+                      }
+              })
+            expect(s.result.to_sql).not_to match /LEFT OUTER JOIN/
+          end
+
           it 'should keep proper key value pairs in the params hash' do
             s = Person.ransack(children_reversed_name_eq: 'Testing')
             expect(s.result.to_sql).to match /LEFT OUTER JOIN/


### PR DESCRIPTION
# Description

When a condition in the advanced search hash has an empty value, the condition is not removed so the "LEFT OUTER JOIN" is added to the SQL query without a "WHERE" clause.

# Problem

The behavior is not the same when using a simple condition hash (example: `{children_name_eq: ''}`) versus using an advanced search hash (example: `{c: {'0' => {a: ['children_name'], p: 'eq', v: ['']}}}`).

The first example results in the following query :
```sql
SELECT "people".* FROM "people" ORDER BY "people"."id" DESC
```
The second example results in the following query :
```sql
SELECT "people".* FROM "people" LEFT OUTER JOIN "people" "children_people" ON "children_people"."parent_id" = "people"."id" ORDER BY "people"."id" DESC
```

# Proposed solution

I added code to remove conditions with a blank value in the same way it is done with the simple condition.
Do you see a better way to handle this ?