### PR TITLE
Allow nil values in array

### DIFF
--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -26,7 +26,7 @@ module Ransack
       if params.is_a? Hash
         params = params.dup
         params = params.transform_values { |v| v.is_a?(String) && strip_whitespace ? v.strip : v }
-        params.delete_if { |k, v| [*v].all?{ |i| i.blank? && i != false } }
+        params.delete_if { |k, v| [*v].all?{ |i| i.blank? && i != false && !i.nil? } }
       else
         params = {}
       end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -75,6 +75,12 @@ module Ransack
         Search.new(Person, name_eq_any: ['foobar'])
       end
 
+      it 'keeps conditions with a nil value in an array before building' do
+        expect_any_instance_of(Search).to receive(:build)
+        .with({ 'name_in' => [nil] })
+        Search.new(Person, name_in: [nil])
+      end
+
       it 'does not raise exception for string :params argument' do
         expect { Search.new(Person, '') }.not_to raise_error
       end


### PR DESCRIPTION
I’ve noticed some inconsistent behavior when using the _in predicate in Ransack compared to ActiveRecord.

For example, in plain Rails:

```
Vehicle.where(brand: [nil])
# => SELECT "vehicles".* FROM "vehicles" WHERE "vehicles"."brand" IS NULL
```

```
Vehicle.where(brand: [nil, 'AUDI'])
# => SELECT "vehicles".* FROM "vehicles" WHERE ("vehicles"."brand" = $1 OR "vehicles"."brand" IS NULL)
```

We use Ransack in our API. Since Rails automatically strips any nil values from an array in params, it's not possible for us to use the standard `_in` predicate in our API. To accomplish this I've introduced a custom predicate `_in_or_null` as described here: https://github.com/activerecord-hackery/ransack/issues/940#issuecomment-1410704480

This allows me to perform the second example by using `brand_in_or_null: [ "AUDI" ]`, however if I would use `brand_in_or_null: []`, I would expect this to only give me the vehicles where the brand is null, however the current logic deletes the param and returns all records. 

I've changed the logic in the Search class initializer, where it now allows an array with nil values.

Possibly related to: https://github.com/activerecord-hackery/ransack/issues/524