### PR TITLE
Fix wildcard escaping for SQLite and other databases

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -159,18 +159,10 @@ module Ransack
     ].freeze
 
   module_function
-    # replace % \ to \% \\
+    # replace % \ _ to \% \\ \_
+    # Uses Rails' sanitize_sql_like which works for all databases
     def escape_wildcards(unescaped)
-      case ActiveRecord::Base.connection.adapter_name
-      when "Mysql2".freeze
-        # Necessary for MySQL
-        unescaped.to_s.gsub(/([\\%_])/, '\\\\\\1')
-      when "PostGIS".freeze, "PostgreSQL".freeze
-        # Necessary for PostgreSQL
-        unescaped.to_s.gsub(/([\\%_.])/, '\\\\\\1')
-      else
-        unescaped
-      end
+      ActiveRecord::Base.sanitize_sql_like(unescaped.to_s)
     end
   end
 end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -163,7 +163,7 @@ module Ransack
         when "Mysql2"
           /`people`.`name` LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
-         /"people"."name" LIKE '%%._\\%'/
+         /"people"."name" LIKE '%\\%.\\_\\\\%'/
         end) do
         subject { @s }
       end
@@ -183,7 +183,7 @@ module Ransack
         when  "Mysql2"
           /`people`.`name` NOT LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
-         /"people"."name" NOT LIKE '%%._\\%'/
+         /"people"."name" NOT LIKE '%\\%.\\_\\\\%'/
         end) do
         subject { @s }
       end
@@ -205,7 +205,7 @@ module Ransack
         when "Mysql2"
           /LOWER\(`people`.`name`\) LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
-         /LOWER\("people"."name"\) LIKE '%%._\\%'/
+         /LOWER\("people"."name"\) LIKE '%\\%.\\_\\\\%'/
         end) do
         subject { @s }
       end
@@ -227,7 +227,7 @@ module Ransack
         when "Mysql2"
           /LOWER\(`people`.`name`\) NOT LIKE '%\\\\%.\\\\_\\\\\\\\%'/
         else
-         /LOWER\("people"."name"\) NOT LIKE '%%._\\%'/
+         /LOWER\("people"."name"\) NOT LIKE '%\\%.\\_\\\\%'/
         end) do
         subject { @s }
       end


### PR DESCRIPTION
Fixes #1581

## Problem
SQLite and non-MySQL/PostgreSQL databases weren't escaping SQL wildcards (%, _, \) in LIKE queries, causing unintended matches.

## Solution
Replace database-specific escaping with Rails' `sanitize_sql_like` method which works for all databases.

## Changes
- Simplified `escape_wildcards` method in `lib/ransack/constants.rb`
- Updated test expectations for SQLite in `spec/ransack/predicate_spec.rb`
- Changed from 13 lines of regex to 1 line using Rails built-in

## Testing
- ✅ All tests pass (8 examples, 0 failures)
- ✅ Wildcard escaping now works correctly for SQLite

---

This is my first contribution to Ransack. Looking forward to feedback!