### PR TITLE
Allow empty string and empty array as valid search values

### DIFF
--- a/lib/ransack/predicate.rb
+++ b/lib/ransack/predicate.rb
@@ -37,8 +37,7 @@ module Ransack
       @arel_predicate = opts[:arel_predicate]
       @type = opts[:type]
       @formatter = opts[:formatter]
-      @validator = opts[:validator] ||
-        lambda { |v| v.respond_to?(:empty?) ? !v.empty? : !v.nil? }
+      @validator = opts[:validator] || lambda { |v| !v.nil? }
       @compound = opts[:compound]
       @wants_array = opts.fetch(:wants_array,
         @compound || Constants::IN_NOT_IN.include?(@arel_predicate))
@@ -64,6 +63,7 @@ module Ransack
     end
 
     def validate(vals, type = @type)
+      return true if vals.empty? && wants_array
       vals.any? { |v| validator.call(type ? v.cast(type) : v.value) }
     end
 

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -26,7 +26,7 @@ module Ransack
       if params.is_a? Hash
         params = params.dup
         params = params.transform_values { |v| v.is_a?(String) && strip_whitespace ? v.strip : v }
-        params.delete_if { |k, v| [*v].all?{ |i| i.blank? && i != false } }
+        params.delete_if { |k, v| v.nil? || (v.is_a?(Array) && !v.empty? && v.all?(&:nil?)) }
       else
         params = {}
       end

--- a/spec/ransack/adapters/active_record/base_spec.rb
+++ b/spec/ransack/adapters/active_record/base_spec.rb
@@ -357,8 +357,14 @@ module Ransack
             expect(s.result.count).to eq 1
           end if defined?(Arel::Nodes::InfixOperation) && sane_adapter?
 
-          it 'should remove empty key value pairs from the params hash' do
+          it 'should keep empty string values in the params hash and search for them' do
             s = Person.ransack(children_reversed_name_eq: '')
+            expect(s.result.to_sql).to match /LEFT OUTER JOIN/
+            expect(s.result.to_sql).to match(/= ''/)
+          end
+
+          it 'should remove nil key value pairs from the params hash' do
+            s = Person.ransack(children_reversed_name_eq: nil)
             expect(s.result.to_sql).not_to match /LEFT OUTER JOIN/
           end
 

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -3,15 +3,22 @@ require 'spec_helper'
 module Ransack
   describe Search do
     describe '#initialize' do
-      it 'removes empty conditions before building' do
-        expect_any_instance_of(Search).to receive(:build).with({})
-        Search.new(Person, name_eq: '')
-      end
-
       it 'keeps conditions with a false value before building' do
         expect_any_instance_of(Search).to receive(:build)
         .with({ 'name_eq' => false })
         Search.new(Person, name_eq: false)
+      end
+
+      it 'keeps empty array conditions before building' do
+        expect_any_instance_of(Search).to receive(:build)
+        .with({ 'name_in' => [] })
+        Search.new(Person, name_in: [])
+      end
+
+      it 'keeps empty string conditions before building' do
+        expect_any_instance_of(Search).to receive(:build)
+        .with({ 'name_eq' => '' })
+        Search.new(Person, name_eq: '')
       end
 
       it 'keeps conditions with a value before building' do
@@ -58,8 +65,14 @@ module Ransack
         end
       end
 
-      it 'removes empty suffixed conditions before building' do
+      it 'removes nil-only array conditions before building' do
         expect_any_instance_of(Search).to receive(:build).with({})
+        Search.new(Person, name_eq_any: [nil, nil])
+      end
+
+      it 'keeps array with empty string before building' do
+        expect_any_instance_of(Search).to receive(:build)
+        .with({ 'name_eq_any' => [''] })
         Search.new(Person, name_eq_any: [''])
       end
 
@@ -183,8 +196,15 @@ module Ransack
         expect(s.result.to_sql).to include 'published'
       end
 
-      it 'discards empty conditions' do
+      it 'keeps empty string conditions' do
         s = Search.new(Person, children_name_eq: '')
+        condition = s.base[:children_name_eq]
+        expect(condition).not_to be_nil
+        expect(condition.values.first.value).to eq ''
+      end
+
+      it 'discards nil conditions' do
+        s = Search.new(Person, children_name_eq: nil)
         condition = s.base[:children_name_eq]
         expect(condition).to be_nil
       end
@@ -330,8 +350,8 @@ module Ransack
           Ransack.configure { |c| c.strip_whitespace = true }
         end
 
-        it 'removes whitespace-only values' do
-          expect_any_instance_of(Search).to receive(:build).with({})
+        it 'keeps whitespace-only values as empty strings after stripping' do
+          expect_any_instance_of(Search).to receive(:build).with({ 'name_eq' => '' })
           Search.new(Person, name_eq: '   ')
         end
 
@@ -462,6 +482,16 @@ module Ransack
         expect(s.result).to be_an ActiveRecord::Relation
         expect(s.result.to_sql).to match /#{
           children_people_name_field} = 'Ernie'/
+      end
+
+      it 'returns no results for empty array in _in predicate' do
+        s = Search.new(Person, name_in: [])
+        expect(s.result.to_sql).to match /1=0|IN \(NULL\)/i
+      end
+
+      it 'searches for empty string with _eq predicate' do
+        s = Search.new(Person, name_eq: '')
+        expect(s.result.to_sql).to match /#{people_name_field} = ''/
       end
 
       it 'use appropriate table alias' do


### PR DESCRIPTION
Ransack currently discards empty strings and empty arrays from search params silently.

This might be intentional, but users may not be aware of this behavior or may not want it. If a user passes an empty array, they probably expect no results to be returned. If they pass an empty string, they probably want to find records where the field is actually empty.

Currently, passing empty values causes a full table scan because all conditions are removed. This could potentially lead to OOM issues (unless pagination is in place).

With this change:
  - `name_eq: ''` generates `WHERE name = ''`
  - `id_in: []` generates `WHERE 1=0` (returns no results)
  - `name_eq: nil` is still ignored (existing behavior preserved)

Related: #1592, #722