### PR TITLE
support enum

### DIFF
--- a/lib/ransack/nodes/attribute.rb
+++ b/lib/ransack/nodes/attribute.rb
@@ -31,6 +31,8 @@ module Ransack
       def type
         if ransacker
           ransacker.type
+        elsif enum?
+          :enum
         else
           context.type_for(self)
         end
@@ -52,6 +54,14 @@ module Ransack
 
       def inspect
         "Attribute <#{name}>"
+      end
+
+      private
+
+      def enum?
+        bound? &&
+        klass.respond_to?(:defined_enums) &&
+        klass.defined_enums.key?(attr_name.to_s)
       end
 
     end

--- a/lib/ransack/nodes/value.rb
+++ b/lib/ransack/nodes/value.rb
@@ -24,6 +24,8 @@ module Ransack
 
       def cast(type)
         case type
+        when :enum
+          value
         when :date
           cast_to_date(value)
         when :datetime, :timestamp, :time, :timestamptz

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -456,6 +456,49 @@ module Ransack
       let(:notable_type_field) {
         "#{quote_table_name("notes")}.#{quote_column_name("notable_type")}"
       }
+      let(:people_temperament_field) {
+        "#{quote_table_name("people")}.#{quote_column_name("temperament")}"
+      }
+
+      context 'when evaluating enums' do
+        before do
+          Person.first.update_attribute(:temperament, 'choleric')
+        end
+
+        it 'evaluates enum key correctly' do
+          s = Search.new(Person, temperament_eq: 'choleric')
+
+          expect(s.result.to_sql).not_to match(/#{people_temperament_field} = 0/)
+          expect(s.result.to_sql).to match(/#{people_temperament_field} = #{Person.temperaments[:choleric]}/)
+          expect(s.result).not_to be_empty
+        end
+
+        it 'evaluates enum value correctly' do
+          s = Search.new(Person, temperament_eq: Person.temperaments[:choleric])
+
+          expect(s.result.to_sql).not_to match(/#{people_temperament_field} = 0/)
+          expect(s.result.to_sql).to match(/#{people_temperament_field} = #{Person.temperaments[:choleric]}/)
+          expect(s.result).not_to be_empty
+        end
+      end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1644
+      context 'when enum fix does not break boolean predicate casting' do
+        it 'casts 0 to false for not_null predicate' do
+          s = Search.new(Person, name_not_null: 0)
+          expect(s.result.to_sql).to match(/#{people_name_field} IS NULL/)
+        end
+
+        it 'casts 1 to true for not_null predicate' do
+          s = Search.new(Person, name_not_null: 1)
+          expect(s.result.to_sql).to match(/#{people_name_field} IS NOT NULL/)
+        end
+
+        it 'casts "false" to false for not_null predicate' do
+          s = Search.new(Person, name_not_null: 'false')
+          expect(s.result.to_sql).to match(/#{people_name_field} IS NULL/)
+        end
+      end
 
       it 'evaluates conditions contextually' do
         s = Search.new(Person, children_name_eq: 'Ernie')

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -64,6 +64,8 @@ class Person < ApplicationRecord
   has_many   :articles
   has_many   :story_articles
 
+  enum :temperament, { sanguine: 1, choleric: 2, melancholic: 3, phlegmatic: 4 }
+
   has_many :published_articles, ->{ where(published: true) },
       class_name: "Article"
   has_many   :comments
@@ -304,6 +306,7 @@ module Schema
         t.boolean  :awesome, default: false
         t.boolean  :terms_and_conditions, default: false
         t.boolean  :true_or_false, default: true
+        t.integer  :temperament
         t.timestamps null: false
       end
 


### PR DESCRIPTION
Fixes #1555
Related: #1644

## Problem

When searching enum attributes by key (e.g., `temperament_eq: 'choleric'`), Ransack identified the column type as `:integer` and cast the value via `String#to_i`, resulting in `'choleric'.to_i == 0`. This produced incorrect queries like `WHERE temperament = 0` instead of `WHERE temperament = 2`.

## Solution

In Rails, `Person.where(temperament: 'choleric')` and `Person.where(temperament: 2)` both produce the same query — ActiveRecord handles the mapping internally. Ransack should behave the same way. To achieve this, `Attribute#type` now returns `:enum` for enum attributes, and `Value#cast(:enum)` passes the raw value through to ActiveRecord instead of attempting its own conversion.

A regression test for [#1644](https://github.com/activerecord-hackery/ransack/issues/1644) has also been included to ensure boolean predicate casting remains unaffected.

## Changes

- `Attribute#type` — returns `:enum` when the attribute is a defined enum
- `Value#cast(:enum)` — returns raw value, delegating conversion to ActiveRecord
- Added enum search specs (key and integer value)
- Added regression test for #1644 (boolean predicate casting)