### PR TITLE
Feature Request: Case-insensitive sorting config option

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -44,6 +44,12 @@ module Ransack
               if scope_or_sort.is_a?(Symbol)
                 relation = relation.send(scope_or_sort)
               else
+
+                if Ransack.options[:case_insensitive_sort]
+                  sql = scope_or_sort.to_sql
+                  scope_or_sort = Arel.sql(sql.sub(/\s+(ASC|DESC)\z/i, ' COLLATE NOCASE \1').then { |s| s == sql ? "#{s} COLLATE NOCASE" : s })
+                end
+
                 case Ransack.options[:postgres_fields_sort_option]
                 when :nulls_first
                   scope_or_sort = scope_or_sort.direction == :asc ? Arel.sql("#{scope_or_sort.to_sql} NULLS FIRST") : Arel.sql("#{scope_or_sort.to_sql} NULLS LAST")

--- a/lib/ransack/configuration.rb
+++ b/lib/ransack/configuration.rb
@@ -35,7 +35,8 @@ module Ransack
       default_arrow: nil,
       sanitize_scope_args: true,
       postgres_fields_sort_option: nil,
-      strip_whitespace: true
+      strip_whitespace: true,
+      case_insensitive_sort: false
     }
 
     def configure
@@ -195,6 +196,10 @@ module Ransack
     #
     def strip_whitespace=(boolean)
       self.options[:strip_whitespace] = boolean
+    end
+
+    def case_insensitive_sort=(boolean)
+      self.options[:case_insensitive_sort] = boolean
     end
 
     def arel_predicate_with_suffix(arel_predicate, suffix)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -840,6 +840,53 @@ module Ransack
 
         Ransack.options = default
       end
+
+      it 'sorts with and without case-insensitivity' do
+        default = Ransack.options.clone
+
+        old_values = Person.all.map.with_index do |person, index|
+          old_val = person.only_sort
+          person.update!(only_sort: old_val.upcase) if index.even? && !old_val.nil?
+          [old_val, person.id]
+        end
+        comp = Person.all.map(&:only_sort).sort do |a, b|
+          if a.nil?
+            0
+          elsif b.nil?
+            -1
+          else
+            a <=> b
+          end
+        end
+
+        s = Search.new(Person, s: 'only_sort asc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"only_sort\" ASC"
+        expect(s.result.map(&:only_sort)).to eq comp
+
+        Ransack.configure { |c| c.case_insensitive_sort = true }
+        comp = Person.all.map(&:only_sort).sort do |a, b|
+          if a.nil?
+            0
+          elsif b.nil?
+            -1
+          else
+            a.downcase <=> b.downcase
+          end
+        end
+
+        s = Search.new(Person, s: 'only_sort asc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"only_sort\" COLLATE NOCASE ASC"
+        expect(s.result.map(&:only_sort)).to eq comp
+
+        s = Search.new(Person, s: 'only_sort desc')
+        expect(s.result.to_sql).to eq "SELECT \"people\".* FROM \"people\" ORDER BY \"people\".\"only_sort\" COLLATE NOCASE DESC"
+        expect(s.result.map(&:only_sort)).to eq comp.reverse
+
+        old_values.each do |(old_val, id)|
+          Person.find(id).update_attribute(:only_sort, old_val)
+        end
+        Ransack.options = default
+      end
     end
 
     describe '#method_missing' do


### PR DESCRIPTION
Implemented case_insensitive_sort config option requested in issue [#1652](https://github.com/activerecord-hackery/ransack/issues/1652)

Implemented `case_insensitive_sort` config option. Once enabled, it inserts `COLLATE NOCASE` modifier into generated SQL as requested.

Included tests added to search_spec.rb