### PR TITLE
Add pending spec for #1553 (string-returning formatter with arel_predicate: 'in')

### DIFF
--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -473,6 +473,31 @@ module Ransack
           expect(@s.result.to_sql).to match /#{field} NOT IN \('a', 'b'\)/
         end
       end
+
+      # Pending spec for https://github.com/activerecord-hackery/ransack/issues/1553
+      # When a custom predicate uses arel_predicate: 'in' together with a formatter
+      # that builds the inner SQL fragment manually (e.g. joining with "','"),
+      # ActiveRecord double-escapes the single quotes, producing IN ('a'',''b')
+      # instead of IN ('a', 'b').
+      #
+      # Marked pending because the fix direction needs a design call. See the
+      # discussion on the linked issue.
+      describe "with 'in' arel predicate and a string-returning formatter" do
+        before do
+          Ransack.configure do |c|
+            c.add_predicate "in_list",
+              arel_predicate: "in",
+              formatter: proc { |v| v&.split(";")&.join("','") }
+          end
+        end
+
+        it 'does not double-escape single quotes in the formatted value' do
+          pending "https://github.com/activerecord-hackery/ransack/issues/1553"
+          @s.name_in_list = "Aaron;Ernie"
+          field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+          expect(@s.result.to_sql).to match /#{field} IN \('Aaron', 'Ernie'\)/
+        end
+      end
     end
 
     private


### PR DESCRIPTION
Adds a pending spec capturing the SQL generation bug reported in #1553.

When a custom predicate is defined with `arel_predicate: 'in'` and a formatter that builds the inner SQL fragment manually — e.g. joining with `"','"` — ActiveRecord double-escapes the single quotes, producing `IN ('Aaron'',''Ernie')` instead of `IN ('Aaron', 'Ernie')`.

The spec is added alongside the existing `not_in_csv` example in `spec/ransack/predicate_spec.rb` and marked `pending` linked to #1553.

## Why pending

Tracing through `lib/ransack/nodes/condition.rb#formatted_values_for_attribute`, Arel can't safely interpret a formatter's joined string as a multi-element IN list — it will always quote it as a single value. The practical fix paths are (1) raise a clearer error when a `wants_array` predicate's formatter returns a non-Array, (2) document that such formatters must return Arrays, or (3) both.

I'll add an analysis comment on #1553 for discussion. Once the direction is decided, a follow-up PR can drop the `pending` marker and apply the fix.

Targets `v5.0.0` per #1640.