### PR TITLE
Fix scopes inside groupings being silently dropped (#1339, #1490)

### DIFF
--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -89,6 +89,14 @@ module Ransack
       @klass.method(scope).arity
     end
 
+    def sanitize_scope_args(key, args)
+      if Ransack.options[:sanitize_scope_args] && !ransackable_scope_skip_sanitize_args?(key, object)
+        cast_scope_args(args)
+      else
+        args
+      end
+    end
+
     def bind(object, str)
       return nil unless str
       object.parent, object.attr_name = bind_pair_for(str)
@@ -185,6 +193,22 @@ module Ransack
 
     def searchable_associations(str = ''.freeze)
       traverse(str).ransackable_associations(auth_object)
+    end
+
+    private
+
+    def cast_scope_args(args)
+      if args.is_a?(Array)
+        args = args.map(&method(:cast_scope_args))
+      end
+
+      if Constants::TRUE_VALUES.include? args
+        true
+      elsif Constants::FALSE_VALUES.include? args
+        false
+      else
+        args
+      end
     end
   end
 end

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -152,7 +152,11 @@ module Ransack
           when /^(g|c|m)$/
             self.send("#{key}=", value)
           else
-            write_attribute(key.to_s, value)
+            if @context.ransackable_scope?(key, @context.object)
+              @context.chain_scope(key, @context.sanitize_scope_args(key, value))
+            else
+              write_attribute(key.to_s, value)
+            end
           end
         end
         self

--- a/lib/ransack/search.rb
+++ b/lib/ransack/search.rb
@@ -132,11 +132,7 @@ module Ransack
     private
 
     def add_scope(key, args)
-      sanitized_args = if Ransack.options[:sanitize_scope_args] && !@context.ransackable_scope_skip_sanitize_args?(key, @context.object)
-        sanitized_scope_args(args)
-      else
-        args
-      end
+      sanitized_args = @context.sanitize_scope_args(key, args)
 
       if @context.scope_arity(key) == 1
         @scope_args[key] = args.is_a?(Array) ? args[0] : args
@@ -144,20 +140,6 @@ module Ransack
         @scope_args[key] = args.is_a?(Array) ? sanitized_args : args
       end
       @context.chain_scope(key, sanitized_args)
-    end
-
-    def sanitized_scope_args(args)
-      if args.is_a?(Array)
-        args = args.map(&method(:sanitized_scope_args))
-      end
-
-      if Constants::TRUE_VALUES.include? args
-        true
-      elsif Constants::FALSE_VALUES.include? args
-        false
-      else
-        args
-      end
     end
 
     def collapse_multiparameter_attributes!(attrs)

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -456,13 +456,13 @@ module Ransack
 
         it "applies the scope when it is the only key inside a grouping" do
           s = Search.new(Person, g: [{ over_age: 18 }])
-          expect(s.result.to_sql).to match(/age > 18/)
+          expect(s.result.to_sql).to match(/age > '?18'?/)
         end
 
         it "applies the scope alongside other conditions in the same grouping" do
           s = Search.new(Person, g: [{ name_eq: 'Aaron', over_age: 18 }])
           sql = s.result.to_sql
-          expect(sql).to match(/age > 18/)
+          expect(sql).to match(/age > '?18'?/)
           expect(sql).to match(/name.* = 'Aaron'/)
         end
       end

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -444,6 +444,28 @@ module Ransack
           }.not_to raise_error
         end
       end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1339
+      # Scopes nested inside groupings (`g: [...]`) were silently dropped
+      # rather than applied to the query.
+      context "ransackable_scope inside groupings" do
+        before do
+          allow(Person).to receive(:ransackable_scopes)
+            .and_return(Person.ransackable_scopes + [:over_age])
+        end
+
+        it "applies the scope when it is the only key inside a grouping" do
+          s = Search.new(Person, g: [{ over_age: 18 }])
+          expect(s.result.to_sql).to match(/age > 18/)
+        end
+
+        it "applies the scope alongside other conditions in the same grouping" do
+          s = Search.new(Person, g: [{ name_eq: 'Aaron', over_age: 18 }])
+          sql = s.result.to_sql
+          expect(sql).to match(/age > 18/)
+          expect(sql).to match(/name.* = 'Aaron'/)
+        end
+      end
     end
 
     describe '#result' do


### PR DESCRIPTION
Closes #1339.
Closes #1490 (same bug — `Ransack doesn't lookup scope when using groupings`, listed as a sub-task of #1640).

Related: #653 (the original `Custom Scopes with groupings?` feature request in the Backlog milestone).

## Problem

When a ransackable scope is nested inside a grouping, it is silently dropped:

```ruby
Product.ransack(g: [{ priced_above: 5000 }]).result.to_sql
# => SELECT "products".* FROM "products"     ← scope ignored
```

The non-grouping case works as expected:

```ruby
Product.ransack(priced_above: 5000).result.to_sql
# => SELECT "products".* FROM "products" WHERE (price > 5000)
```

Mixed conditions in the same grouping silently drop the scope while applying the other condition:

```ruby
Product.ransack(g: [{ id_eq: 3, priced_above: 5000 }], m: "and").result.to_sql
# => SELECT "products".* FROM "products" WHERE "products"."id" = 3   ← scope dropped
```

## Cause

`Grouping#build` only matches `g`/`c`/`m` keys and otherwise routes through `write_attribute → Condition.extract`, which has no knowledge of scopes. Scope handling lived only in `Search#build`, so any scope key under `g:` fell through and was discarded.

## Fix

`Grouping#build` now recognises scope keys via `Context#ransackable_scope?` and applies them with `Context#chain_scope`, matching the top-level behaviour in `Search#add_scope`.

To keep sanitisation in one place, `sanitize_scope_args` is moved from `Search` to `Context` (and the previous private `sanitized_scope_args` helper becomes a private `cast_scope_args` on `Context`). Both call sites now share it, so the `sanitize_scope_args` config and `ransackable_scopes_skip_sanitize_args` opt-out continue to apply to grouping-level scopes.

## Tests

Two new specs under `Ransack::Search#build > ransackable_scope inside groupings` in `spec/ransack/search_spec.rb`, both red before the fix and green after:

- scope as the only key inside a grouping
- scope alongside another condition in the same grouping

Full suite: `511 examples, 0 failures` on `v5.0.0` + this branch, across SQLite, PostgreSQL, PostGIS, and MySQL on Rails 7.2-stable / 8.0-stable.

## A note on semantics

As with top-level scopes, the scope is applied to the underlying relation rather than composed into the grouping's AND/OR tree. This preserves the existing "bolt-on" model that @Roguelazer described in the issue. Full composition (e.g. a scope inside an `m: "or"` grouping) would require a larger refactor and is left for a follow-up — that is the territory of #653.

Targets `v5.0.0` per #1640.