### PR TITLE
Fix low-level c: API silently dropping conditions with Array envelope hashes (#1150)

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -81,8 +81,13 @@ module Ransack
       def attributes=(args)
         case args
         when Array
-          args.each do |name|
-            build_attribute(name)
+          args.each do |attr|
+            if attr.is_a?(Hash) && (attr.key?(:name) || attr.key?("name"))
+              attr = attr.with_indifferent_access
+              build_attribute(attr[:name], attr[:ransacker_args])
+            else
+              build_attribute(attr)
+            end
           end
         when Hash
           args.each do |index, attrs|
@@ -104,8 +109,10 @@ module Ransack
         case args
         when Array
           args.each do |val|
-            val = Value.new(@context, val)
-            self.values << val
+            if val.is_a?(Hash) && (val.key?(:value) || val.key?("value"))
+              val = val.with_indifferent_access[:value]
+            end
+            self.values << Value.new(@context, val)
           end
         when Hash
           args.each do |index, attrs|

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -242,6 +242,38 @@ module Ransack
         .to eq [Nodes::Condition, Nodes::Condition]
       end
 
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1150
+      # The low-level `c:` API previously only worked when `a:` and `v:` were given
+      # in their Hash form (`{"0" => {name: ...}}`). When supplied as Arrays of
+      # attribute / value envelopes (`[{name: ...}]`, `[{value: ...}]`) the parser
+      # silently dropped the attribute or treated the entire envelope hash as the
+      # value.
+      context 'low-level c: API with Array of envelope hashes' do
+        it 'extracts :name from each attribute hash inside an Array' do
+          s = Search.new(Person,
+            c: [{ a: [{ name: 'name' }], p: 'cont', v: [{ value: 'Ernie' }] }]
+          )
+          field = "#{quote_table_name('people')}.#{quote_column_name('name')}"
+          expect(s.result.to_sql).to match(/#{field} I?LIKE '%Ernie%'/)
+        end
+
+        it 'extracts :value from each value hash inside an Array' do
+          s = Search.new(Person,
+            c: [{ a: { '0' => { name: 'name' } }, p: 'cont', v: [{ value: 'Ernie' }] }]
+          )
+          field = "#{quote_table_name('people')}.#{quote_column_name('name')}"
+          expect(s.result.to_sql).to match(/#{field} I?LIKE '%Ernie%'/)
+        end
+
+        it 'still accepts plain Array of names/values (canonical form)' do
+          s = Search.new(Person,
+            c: [{ a: ['name'], p: 'cont', v: ['Ernie'] }]
+          )
+          field = "#{quote_table_name('people')}.#{quote_column_name('name')}"
+          expect(s.result.to_sql).to match(/#{field} I?LIKE '%Ernie%'/)
+        end
+      end
+
       it 'creates conditions for custom predicates that take arrays' do
         Ransack.configure do |config|
           config.add_predicate 'ary_pred', wants_array: true


### PR DESCRIPTION
Closes #1150.

## Problem

The low-level conditions API (`c: [{a:, v:, p:}]`) accepts `a:` (attributes) and `v:` (values) in two equivalent forms:

- Hash form: `a: {'0' => {name: 'foo'}}`, `v: {'0' => {value: 'bar'}}`
- Array form: `a: ['foo']`, `v: ['bar']`

However when the Array form contained the same envelope hash that the Hash form unwraps, the parser did the wrong thing.

**Bug 1 — `a:` Array of `{name: ...}` envelopes silently drops the condition:**

```ruby
Contact.ransack(g: [{ c: [{ a: [{ name: 'name' }], v: [{ value: 'Kasper' }], p: 'cont' }], m: 'and' }]).result.to_sql
# => SELECT "contacts".* FROM "contacts"
#    ^ no WHERE clause
```

**Bug 2 — `v:` Array of `{value: ...}` envelopes leaks the whole hash into the SQL:**

```ruby
Contact.ransack(g: [{ c: [{ a: { '0' => { name: 'name' } }, v: [{ value: 'Kasper' }], p: 'cont' }], m: 'and' }]).result.to_sql
# => SELECT "contacts".* FROM "contacts" WHERE "contacts"."name" LIKE '%{"value" => "Kasper"}%'
```

The Hash form of both `a:` and `v:` worked correctly, so the asymmetry was the bug.

## Cause

`Condition#attributes=` and `#values=` switch on `Array`/`Hash`. The Hash branches unwrap each entry's `:name` / `:value`, but the Array branches assumed every element was a plain name or plain value. When an envelope hash was supplied, it was passed straight through:

- `attributes=` Array branch: `Attribute.new(@context, {name: 'name'}, [])` was built, failed `valid?`, and was dropped.
- `values=` Array branch: `Value.new(@context, {value: 'Kasper'})` was built, which later renders the hash via `to_s` inside the SQL.

## Fix

In the Array branch of each setter, detect envelope hashes (with `:name` or `:value` keys, either symbol or string) and extract the same fields the Hash branch already does. Plain Array elements (the canonical `a: ['name']`, `v: ['Ernie']` form used throughout existing specs) continue to work unchanged.

## Compatibility

The Array branches keep the existing behavior for every shape **except** the two envelope forms documented as broken in #1150:

| `a:` / `v:` element shape          | Before     | After     |
| ---------------------------------- | ---------- | --------- |
| `"foo"` (plain name / value)       | works      | works     |
| `{name: ...}` / `{value: ...}`     | **broken** | **fixed** |
| `{"name" => ...}` (string key)     | broken     | fixed     |
| `{name:, ransacker_args:}`         | broken     | fixed     |
| `{other_key: ...}` (no envelope)   | unchanged  | unchanged |
| `nil`                              | unchanged  | unchanged |

The envelope-detection check is intentionally narrow (`Hash` *and* has a `:name`/`:value` key) so that arbitrary Hash values — e.g. searches against a JSON column where the value itself is a Hash — keep flowing through Arel unchanged.

CI is green on the full matrix (SQLite / PostgreSQL / PostGIS / MySQL × Rails 7.2-stable / 8.0-stable × Ruby 3.1.4 / 3.2.2).

## Tests

Three new specs under `Ransack::Search#build > low-level c: API with Array of envelope hashes` in `spec/ransack/search_spec.rb`:

- extracts `:name` from each attribute hash inside an Array (red before, green after)
- extracts `:value` from each value hash inside an Array (red before, green after)
- still accepts plain Array of names/values, i.e. canonical form (green before and after — guards against regression)

Full suite: `515 examples, 0 failures, 1 pending` on `v5.0.0` + this branch (SQLite, ActiveRecord 7.2.3.1, Ruby 3.4.9).

Targets `v5.0.0` per #1640.