### PR TITLE
Make search_form_* helpers honour per-search search_key (#1118)

### DIFF
--- a/lib/ransack/helpers/form_helper.rb
+++ b/lib/ransack/helpers/form_helper.rb
@@ -10,7 +10,7 @@ module Ransack
         search = extract_search_and_set_url(record, options, 'search_form_for')
         options[:html] ||= {}
         html_options = build_html_options(search, options, :get)
-        finalize_form_options(options, html_options)
+        finalize_form_options(search, options, html_options)
         form_for(record, options, &proc)
       end
 
@@ -30,7 +30,7 @@ module Ransack
         search = extract_search_and_set_url(record, options, 'search_form_with')
         options[:html] ||= {}
         html_options = build_html_options(search, options, :get)
-        finalize_form_with_options(options, html_options)
+        finalize_form_with_options(search, options, html_options)
         form_with(model: search, **options, &proc)
       end
 
@@ -48,7 +48,7 @@ module Ransack
         turbo_options = build_turbo_options(options)
         method = options.delete(:method) || :post
         html_options = build_html_options(search, options, method).merge(turbo_options)
-        finalize_form_options(options, html_options)
+        finalize_form_options(search, options, html_options)
         form_for(record, options, &proc)
       end
 
@@ -122,14 +122,14 @@ module Ransack
           }
         end
 
-        def finalize_form_options(options, html_options)
-          options[:as] ||= Ransack.options[:search_key]
+        def finalize_form_options(search, options, html_options)
+          options[:as] ||= search.context.search_key
           options[:html].reverse_merge!(html_options)
           options[:builder] ||= FormBuilder
         end
 
-        def finalize_form_with_options(options, html_options)
-          options[:scope] ||= Ransack.options[:search_key]
+        def finalize_form_with_options(search, options, html_options)
+          options[:scope] ||= search.context.search_key
           options[:html].reverse_merge!(html_options)
           options[:builder] ||= FormBuilder
         end

--- a/spec/ransack/helpers/form_helper_spec.rb
+++ b/spec/ransack/helpers/form_helper_spec.rb
@@ -859,6 +859,21 @@ module Ransack
         it { should match /example_name_eq/ }
       end
 
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1118
+      # When a per-search `search_key:` option is passed to `Person.ransack`,
+      # `search_form_for` should honour it instead of falling back to the
+      # global `Ransack.options[:search_key]`. `sort_link` and `sort_url`
+      # already read this from the search's context.
+      describe '#search_form_for with per-search search_key' do
+        subject {
+          @controller.view_context
+          .search_form_for(Person.ransack({}, search_key: :people_search)) { |f|
+            f.text_field :name_eq
+          }
+        }
+        it { should match /people_search_name_eq/ }
+      end
+
       describe '#search_form_with with default format' do
         subject { @controller.view_context
           .search_form_with(model: Person.ransack) {} }
@@ -901,6 +916,17 @@ module Ransack
           .search_form_with(model: Person.ransack) { |f| f.text_field :name_eq }
         }
         it { should match /example\[name_eq\]/ }
+      end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1118
+      describe '#search_form_with with per-search search_key' do
+        subject {
+          @controller.view_context
+          .search_form_with(model: Person.ransack({}, search_key: :people_search)) { |f|
+            f.text_field :name_eq
+          }
+        }
+        it { should match /people_search\[name_eq\]/ }
       end
 
       describe '#search_form_with without Ransack::Search object' do


### PR DESCRIPTION
Closes #1118.

## Problem

When a `search_key:` is passed to `Model.ransack`, the form-building helpers ignore it. The inputs are emitted under the global default key (`q[...]`) regardless of the override:

```ruby
q = Person.ransack({}, search_key: :people_search)
search_form_for(q) { |f| f.text_field :name_eq }
# => <input type="text" name="q[name_eq]" id="q_name_eq" />
#                       ^^^ should be people_search[name_eq] / people_search_name_eq
```

The same applies to `search_form_with` and `turbo_search_form_for`. `sort_link` and `sort_url` already read the key from the search's context, so the form path is the outlier.

## Cause

The two private finalisers used the global default instead of asking the search:

```ruby
def finalize_form_options(options, html_options)
  options[:as] ||= Ransack.options[:search_key]   # <- global, ignores per-search override
  ...
end

def finalize_form_with_options(options, html_options)
  options[:scope] ||= Ransack.options[:search_key] # <- same
  ...
end
```

The reporter linked both lines in #1118.

## Fix

`finalize_form_options` / `finalize_form_with_options` now take the `search` and read `search.context.search_key`, the same source `sort_link` / `sort_url` already use (see `lib/ransack/helpers/form_helper.rb#L200` and `#L249`).

`Context#search_key` is initialised as `options[:search_key] || Ransack.options[:search_key]`, so the global default still applies when no per-search override is given.

## Compatibility

| `Model.ransack` call                                          | Before                              | After                                  |
| ------------------------------------------------------------- | ----------------------------------- | -------------------------------------- |
| `Person.ransack(...)`                                         | inputs under `q[...]` (global default) | inputs under `q[...]` (unchanged)      |
| `Person.ransack(...)` after `Ransack.configure { ... :example }` | inputs under `example[...]` (global) | inputs under `example[...]` (unchanged) |
| `Person.ransack(..., search_key: :people_search)`             | inputs under `q[...]` ❌ (#1118)     | inputs under `people_search[...]` ✓    |
| `options[:as]` / `options[:scope]` explicitly set by caller   | wins via `||=`                      | wins via `||=` (unchanged)             |

The `finalize_form_*` methods are `private`, so the signature change is internal.

## Tests

Two new specs in `spec/ransack/helpers/form_helper_spec.rb`, alongside the existing global-default tests, both red before the fix and green after:

- `#search_form_for with per-search search_key` -> expects `people_search_name_eq`
- `#search_form_with with per-search search_key` -> expects `people_search[name_eq]`

Full suite: `514 examples, 0 failures, 1 pending` on `v5.0.0` + this branch (SQLite, ActiveRecord 7.2.3.1, Ruby 3.4.9).

Targets `v5.0.0` per #1640.