### PR TITLE
Remove duplicate definitions causing method-redefined warnings (#1434)

### DIFF
--- a/lib/ransack/context.rb
+++ b/lib/ransack/context.rb
@@ -4,7 +4,6 @@ module Ransack
   class Context
     attr_reader :search, :object, :klass, :base, :engine, :arel_visitor
     attr_accessor :auth_object, :search_key
-    attr_reader :arel_visitor
 
     class << self
 

--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -217,10 +217,6 @@ module Ransack
       end
       alias :p :predicate_name
 
-      def arel_predicate
-        raise "not implemented"
-      end
-
       def validated_values
         values.select { |v| predicate.validator.call(v.value) }
       end

--- a/lib/ransack/nodes/grouping.rb
+++ b/lib/ransack/nodes/grouping.rb
@@ -1,7 +1,6 @@
 module Ransack
   module Nodes
     class Grouping < Node
-      attr_reader :conditions
       attr_accessor :combinator
       alias :m :combinator
       alias :m= :combinator=


### PR DESCRIPTION
Closes #1434.

## Problem

Loading the gem with warnings enabled (e.g. `ruby -W` or RSpec under `-w`) emits three "method redefined" warnings:

```
lib/ransack/nodes/condition.rb:291: warning: method redefined; discarding old arel_predicate
lib/ransack/nodes/condition.rb:220: warning: previous definition of arel_predicate was here
lib/ransack/nodes/grouping.rb:29: warning: method redefined; discarding old conditions
lib/ransack/context.rb:7: warning: method redefined; discarding old arel_visitor
```

The reporter saw the `arel_predicate` one in #1434; the same root cause produces two more.

## Cause

Three methods were defined twice in the same class. In each case the first definition was dead code — it was shadowed by a later real implementation:

| File | Dead definition | Live definition |
| --- | --- | --- |
| `lib/ransack/nodes/condition.rb` | `def arel_predicate; raise "not implemented"; end` (was at L220) | actual implementation at L291 |
| `lib/ransack/nodes/grouping.rb` | `attr_reader :conditions` (was at L4) | `def conditions; @conditions \|\|= []; end` at L29 (lazy-inits the array) |
| `lib/ransack/context.rb` | second `attr_reader :arel_visitor` (was at L7) | already covered by the multi-symbol `attr_reader` one line earlier |

## Fix

Delete the dead definitions. No behavioural change — the live implementations were already the ones in effect at runtime.

## Verification

Before:

```text
$ bundle exec ruby -W -r./lib/ransack -e 'puts "loaded"'
lib/ransack/nodes/condition.rb:291: warning: method redefined; discarding old arel_predicate
lib/ransack/nodes/condition.rb:220: warning: previous definition of arel_predicate was here
lib/ransack/nodes/grouping.rb:29: warning: method redefined; discarding old conditions
lib/ransack/context.rb:7: warning: method redefined; discarding old arel_visitor
loaded
```

After:

```text
$ bundle exec ruby -W -r./lib/ransack -e 'puts "loaded"'
loaded
```

(Two unrelated "assigned but unused variable" warnings in `adapters/active_record/context.rb` remain — different category, out of scope for #1434.)

## Compatibility

The three deleted lines were dead code, shadowed by the live definitions next to them. Behaviour is identical before and after; the only difference is the absence of the warnings on load. Diff is `-6 / +0`.

Full suite: `514 examples, 0 failures, 1 pending` on `v5.0.0` + this branch (SQLite, ActiveRecord 7.2.3.1, Ruby 3.4.9).

Targets `v5.0.0` per #1640.