### PR TITLE
Fix _present / _blank producing always-UNKNOWN clause on non-string columns (#1552)

### DIFF
--- a/lib/ransack/nodes/condition.rb
+++ b/lib/ransack/nodes/condition.rb
@@ -343,13 +343,22 @@ module Ransack
       def format_predicate(attribute)
         arel_pred = arel_predicate_for_attribute(attribute)
         arel_values = formatted_values_for_attribute(attribute)
-        
+
+        # The `present` / `blank` predicate formatters produce `[nil, '']` regardless
+        # of column type. The empty-string half has no meaning on non-string columns:
+        # ActiveRecord casts `''` to NULL for those types, producing the
+        # always-UNKNOWN `column != NULL` (or `column = NULL`) clause. Strip the
+        # empty string when the attribute is not a string-like column.
+        if arel_values.is_a?(Array) && arel_values.include?(''.freeze) && !string_like_attribute?(attribute)
+          arel_values = arel_values.reject { |v| v == ''.freeze }
+        end
+
         # For LIKE predicates, wrap the value in Arel::Nodes.build_quoted to prevent
         # ActiveRecord normalization from affecting wildcard patterns
         if like_predicate?(arel_pred)
           arel_values = Arel::Nodes.build_quoted(arel_values)
         end
-        
+
         predicate = attr_value_for_attribute(attribute).public_send(arel_pred, arel_values)
 
         if in_predicate?(predicate)
@@ -368,6 +377,15 @@ module Ransack
 
       def like_predicate?(arel_predicate)
         arel_predicate == 'matches' || arel_predicate == 'does_not_match'
+      end
+
+      STRING_LIKE_TYPES = %i[string text citext].freeze
+
+      def string_like_attribute?(attribute)
+        type = attribute.type
+        # Treat unknown types as string-like (conservative: keep the existing
+        # empty-string comparison rather than silently dropping it).
+        type.nil? || STRING_LIKE_TYPES.include?(type.to_sym)
       end
 
       def casted_array?(predicate)

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -445,6 +445,24 @@ module Ransack
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
         expect(@s.result.to_sql).to match /#{field} IS NULL OR #{field} = ''/
       end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1552
+      # On non-string columns the empty-string half of the comparison has no
+      # meaning and gets cast to NULL, producing the always-UNKNOWN
+      # `column != NULL` clause. The query should reduce to `IS NOT NULL` only.
+      it 'generates only IS NOT NULL on non-string columns' do
+        @s.salary_present = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("salary")}"
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL/
+        expect(@s.result.to_sql).not_to match(%r{!= NULL})
+      end
+
+      it 'generates only IS NULL on non-string columns when assigned false' do
+        @s.salary_present = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("salary")}"
+        expect(@s.result.to_sql).to match /#{field} IS NULL/
+        expect(@s.result.to_sql).not_to match(%r{= NULL})
+      end
     end
 
     describe 'blank' do
@@ -458,6 +476,21 @@ module Ransack
         @s.name_blank = false
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
         expect(@s.result.to_sql).to match /#{field} IS NOT NULL AND #{field} != ''/
+      end
+
+      # Regression test for https://github.com/activerecord-hackery/ransack/issues/1552
+      it 'generates only IS NULL on non-string columns' do
+        @s.salary_blank = true
+        field = "#{quote_table_name("people")}.#{quote_column_name("salary")}"
+        expect(@s.result.to_sql).to match /#{field} IS NULL/
+        expect(@s.result.to_sql).not_to match(%r{= NULL})
+      end
+
+      it 'generates only IS NOT NULL on non-string columns when assigned false' do
+        @s.salary_blank = false
+        field = "#{quote_table_name("people")}.#{quote_column_name("salary")}"
+        expect(@s.result.to_sql).to match /#{field} IS NOT NULL/
+        expect(@s.result.to_sql).not_to match(%r{!= NULL})
       end
     end
 


### PR DESCRIPTION
Closes #1552.

## Problem

The built-in `_present` (and mirrored `_blank`) predicate produces broken SQL on every non-string column:

```ruby
Product.ransack(stock_present: true).result.to_sql
# => SELECT "products".*
#    FROM "products"
#    WHERE ("products"."stock" IS NOT NULL
#       AND "products"."stock" != NULL)     ← always UNKNOWN
```

The trailing `!= NULL` is never true, so `stock_present: true` returns 0 rows even when every row has a non-null stock. The reporter in #1552 hit the same shape on a Postgres string column with a unique partial index, but it reproduces just as cleanly on any boolean / integer / decimal / datetime column.

String / text columns are unaffected — they correctly produce the documented `IS NOT NULL AND != ''` form.

## Cause

The `present` / `blank` predicate definitions in `lib/ransack/constants.rb` ship a column-type-agnostic formatter:

```ruby
formatter: proc { |v| [nil, ''.freeze].freeze }
```

`Condition#format_predicate` feeds those values into Arel's `NOT_EQ_ALL` / `EQ_ANY`. For non-string columns, ActiveRecord casts `''` to the column type, which is `NULL`, leaving the always-UNKNOWN comparison.

## Fix

`Condition#format_predicate` now strips the empty-string entry from `arel_values` when the attribute is not a string-like column (`:string`, `:text`, `:citext`). The two-clause form is preserved on string / text columns; non-string columns reduce to `IS NOT NULL` (or `IS NULL` for `_blank`) — which matches what `Object#present?` means for those types in Rails.

```ruby
# After:
Product.ransack(stock_present: true).result.to_sql
# => SELECT "products".* FROM "products" WHERE ("products"."stock" IS NOT NULL)
```

## Compatibility

| Column type | Predicate | Before | After |
| --- | --- | --- | --- |
| `:string` / `:text` / `:citext` | `_present` (true) | `IS NOT NULL AND != ''` | `IS NOT NULL AND != ''` ✓ unchanged |
| `:string` / `:text` / `:citext` | `_blank` (true) | `IS NULL OR = ''` | `IS NULL OR = ''` ✓ unchanged |
| `:integer` / `:decimal` / `:boolean` / `:datetime` / etc. | `_present` (true) | `IS NOT NULL AND != NULL` ❌ | `IS NOT NULL` ✓ fixed |
| `:integer` / `:decimal` / `:boolean` / `:datetime` / etc. | `_blank` (true) | `IS NULL OR = NULL` ❌ | `IS NULL` ✓ fixed |
| unknown / `nil` type (e.g. ransackers without explicit type) | `_present` / `_blank` | two-clause form | two-clause form ✓ unchanged (treated as string-like, conservative default) |

The condition for stripping is intentionally narrow:

```ruby
if arel_values.is_a?(Array) && arel_values.include?('') && !string_like_attribute?(attribute)
  arel_values = arel_values.reject { |v| v == '' }
end
```

- Only fires when the formatter actually emitted `''` — custom predicates that don't use that envelope are untouched.
- Only fires when the attribute is provably non-string-like — unknown types keep the existing behaviour.

## Tests

Four new specs in `spec/ransack/predicate_spec.rb`, beside the existing string-column ones:

- `_present` / `_blank` on `salary` (integer) emits only `IS [NOT] NULL`, never `!= NULL` or `= NULL`
- existing `name` (string) tests continue to pass, verifying the two-clause form is preserved

Full suite: `516 examples, 0 failures, 1 pending` on `v5.0.0` + this branch (SQLite, ActiveRecord 7.2.3.1, Ruby 3.4.9).

Targets `v5.0.0` per #1640.