### PR TITLE
Fix deprecation warning and correctness bug when using arel_extensions >= 2.2

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -212,9 +212,9 @@ module Ransack
             end
           when Arel::Nodes::Equality
             pk = primary_key
-            if join_root.left == pk
+            if join_root.left.eql?(pk)
               join_root.right
-            elsif join_root.right == pk
+            elsif join_root.right.eql?(pk)
               join_root.left
             else
               nil


### PR DESCRIPTION
## Problem

When `arel_extensions >= 2.2` is present, `extract_correlated_key` triggers a deprecation warning on every query involving correlated joins:

```
DEPRECATION WARNING: `ArelExtensions::Attributes#==` is now deprecated. Use `.eq` instead.
(called from extract_correlated_key at lib/ransack/adapters/active_record/context.rb:215)
```

Beyond the warning, there is a **silent correctness bug**: `ArelExtensions >= 2.2` overrides `==` on Arel attributes to return an `Arel::Nodes::Equality` SQL predicate node — not a boolean. This means the `if join_root.left == pk` check is always truthy (an Arel node is never `nil`/`false`), so `join_root.right` is returned unconditionally, regardless of whether `join_root.left` is actually the primary key.

## Root cause

```ruby
# arel_extensions/lib/arel_extensions/attributes.rb
def ==(other)
  deprecated 'Use `.eq` instead.'
  Arel::Nodes::Equality.new self, Arel.quoted(other, self)  # returns an Arel node, not a boolean
end
```

## Fix

Replace `==` with `eql?` for the primary key identity check. `Arel::Attributes::Attribute#eql?` performs value-based comparison (name + relation) without going through the ArelExtensions override.

```ruby
# Before
if join_root.left == pk
# After
if join_root.left.eql?(pk)
```

## Verification

```ruby
pk  = User.arel_table[:id]
pk2 = User.arel_table[:id]

pk.equal?(pk2)  # => false (different objects)
pk.eql?(pk2)    # => true  (same name + relation)
pk == pk2       # => Arel::Nodes::Equality (always truthy — the bug)
```