### PR TITLE
Add length predicates for searching by string length

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -155,6 +155,31 @@ module Ransack
         type: :boolean,
         validator: proc { |v| BOOLEAN_VALUES.include?(v) },
         formatter: proc { |v| nil } }
+      ],
+      ['length_eq'.freeze, {
+        arel_predicate: 'eq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lt'.freeze, {
+        arel_predicate: 'lt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lteq'.freeze, {
+        arel_predicate: 'lteq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gt'.freeze, {
+        arel_predicate: 'gt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gteq'.freeze, {
+        arel_predicate: 'gteq'.freeze,
+        type: :integer
+        }
       ]
     ].freeze
 

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -461,6 +461,91 @@ module Ransack
       end
     end
 
+    describe 'length_eq' do
+      it 'generates a LENGTH(column) = value condition' do
+        @s.name_length_eq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_eq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_eq = 8
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 8/
+      end
+    end
+
+    describe 'length_lt' do
+      it 'generates a LENGTH(column) < value condition' do
+        @s.name_length_lt = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) < 5/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_lteq' do
+      it 'generates a LENGTH(column) <= value condition' do
+        @s.name_length_lteq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_lteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 10/
+      end
+
+      it "works with attribute names starting with 'length'" do
+        @s.length_of_name_length_lteq = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_of_name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 5/
+      end
+    end
+
+    describe 'length_gt' do
+      it 'generates a LENGTH(column) > value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gt = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) > 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_gteq' do
+      it 'generates a LENGTH(column) >= value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) >= 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
     context "defining custom predicates" do
       describe "with 'not_in' arel predicate" do
         before do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -304,6 +304,8 @@ module Schema
         t.boolean  :awesome, default: false
         t.boolean  :terms_and_conditions, default: false
         t.boolean  :true_or_false, default: true
+        t.string   :length_field
+        t.string   :length_of_name
         t.timestamps null: false
       end
 


### PR DESCRIPTION
> [!NOTE]
> This PR was opened by **Claude** (Claude Code), acting on behalf of @scarroll32.
> Rebased from @tatematsu-k's #1655.

Closes #1492. Closes #1655.

## What it adds

Five predicates that compare the *length* of a column rather than its contents:

```ruby
Person.ransack(name_length_lteq: 3).result.to_sql
# ... WHERE LENGTH("people"."name") <= 3

Person.ransack(name_length_gt: 10).result
```

`length_eq`, `length_lt`, `length_lteq`, `length_gt`, `length_gteq`.

Previously this needed a ransacker, which is a lot of ceremony for something this common — hence #1492.

`CHAR_LENGTH` is used on PostgreSQL, PostGIS and MySQL; `LENGTH` elsewhere. Both count characters rather than bytes for text columns.

## Changes from the original

**The adapter lookup used `ActiveRecord::Base.connection.adapter_name`** — the soft-deprecated call that #1692 removes from `lib/` entirely. Merging it as written would have put one straight back. Switched to `adapter_class::ADAPTER_NAME`.

**Added Trilogy to the `CHAR_LENGTH` list.** It's MySQL, so it has `CHAR_LENGTH`; the original's `when "Mysql2"` would have silently fallen through to `LENGTH` for Trilogy users. (Trilogy support itself is #1501, still open.) The three-branch `case` collapsed to a list while I was there, since two branches returned the same thing.

## Conflict resolution

`format_predicate` conflicted with #1678's `present`/`blank` guard, which landed after this PR was opened. Both are kept — the guard runs first, then the length dispatch.

`spec/support/schema.rb` conflicted with the `temperament` enum column from #1665. Both column sets kept.

## Verification

All five predicates generate the expected SQL and filter correctly end-to-end:

```
length_eq:    WHERE LENGTH("people"."name") = 3
length_lt:    WHERE LENGTH("people"."name") < 3
length_lteq:  WHERE LENGTH("people"."name") <= 3
length_gt:    WHERE LENGTH("people"."name") > 3
length_gteq:  WHERE LENGTH("people"."name") >= 3

name_length_lteq: 3  =>  ["Jo"]
name_length_gt: 3    =>  ["Jonathan", ...]
```

Full suite: **542 examples, 0 failures, 1 pending** (Rails 8.1.3 / Ruby 3.4.9 / SQLite). RuboCop clean.

## Docs

Five new rows in the Search Matchers table plus a short section explaining the backend difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)